### PR TITLE
Fix white tunnels artifact

### DIFF
--- a/mapboxgl/dark-matter-nolabels.json
+++ b/mapboxgl/dark-matter-nolabels.json
@@ -1224,7 +1224,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(238, 238, 238, 1)"
+        "line-color": "rgba(22, 22, 22, 1)"
       }
     },
     {

--- a/mapboxgl/dark-matter.json
+++ b/mapboxgl/dark-matter.json
@@ -1302,7 +1302,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(238, 238, 238, 1)"
+        "line-color": "rgba(22, 22, 22, 1)"
       }
     },
     {


### PR DESCRIPTION
**Original PR**: https://github.com/CartoDB/basemap-styles/pull/27/files
**Shortcut**: https://app.shortcut.com/cartoteam/story/228966
**Tileserver PR**: https://github.com/CartoDB/mobile-tileserver-mbtiles/pull/65

Apply the fix to both `dark-matter` gl styles
- [X] `dark-matter-gl-style`: http://bmp-01.stag.cartodb.net:1337/compare/vector/#15/40.44874/-3.69435

![basemaps_1](https://user-images.githubusercontent.com/15977491/169812750-a7de6b5d-e60d-4ad2-923a-09d57afec2c4.png)


- [X] `dark-matter-nolabels-gl-style`: http://bmp-01.stag.cartodb.net:1337/compare/vector/#15/40.44874/-3.69435
```
[basemaps-st] ubuntu@bmp-01:/srv/www/tileserver/current/gl-styles/dark-matter-nolabels-gl-style$ diff /tmp/dark-matter-nolabels.json style.json 
1227c1227
<         "line-color": "rgba(22, 22, 22, 1)"
---
>         "line-color": "rgba(238, 238, 238, 1)"
```

![basemaps2](https://user-images.githubusercontent.com/15977491/169812769-a06b38ed-ed7a-4eb8-bbff-9e97743e2a4e.png)
