### PR TITLE
Update dark-matter / dark-matter nolabels to have better legibility

### DIFF
--- a/mapboxgl/dark-matter-nolabels.json
+++ b/mapboxgl/dark-matter-nolabels.json
@@ -29,45 +29,18 @@
       "source-layer": "landcover",
       "filter": [
         "any",
-        [
-          "==",
-          "class",
-          "wood"
-        ],
-        [
-          "==",
-          "class",
-          "grass"
-        ],
-        [
-          "==",
-          "subclass",
-          "recreation_ground"
-        ]
+        ["==", "class", "wood"],
+        ["==", "class", "grass"],
+        ["==", "subclass", "recreation_ground"]
       ],
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              8,
-              "#0e0e0e"
-            ],
-            [
-              9,
-              "#0e0e0e"
-            ],
-            [
-              11,
-              "#0e0e0e"
-            ],
-            [
-              13,
-              "#0e0e0e"
-            ],
-            [
-              15,
-              "#0e0e0e"
-            ]
+            [8, "#0e0e0e"],
+            [9, "#0e0e0e"],
+            [11, "#0e0e0e"],
+            [13, "#0e0e0e"],
+            [15, "#0e0e0e"]
           ]
         },
         "fill-opacity": 1
@@ -79,40 +52,18 @@
       "source": "carto",
       "source-layer": "park",
       "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "national_park"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "national_park"]],
       "layout": {
         "visibility": "visible"
       },
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              8,
-              "#0e0e0e"
-            ],
-            [
-              9,
-              "#0e0e0e"
-            ],
-            [
-              11,
-              "#0e0e0e"
-            ],
-            [
-              13,
-              "#0e0e0e"
-            ],
-            [
-              15,
-              "#0e0e0e"
-            ]
+            [8, "#0e0e0e"],
+            [9, "#0e0e0e"],
+            [11, "#0e0e0e"],
+            [13, "#0e0e0e"],
+            [15, "#0e0e0e"]
           ]
         },
         "fill-opacity": 1,
@@ -125,53 +76,25 @@
       "source": "carto",
       "source-layer": "park",
       "minzoom": 0,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "nature_reserve"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "nature_reserve"]],
       "layout": {
         "visibility": "visible"
       },
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              8,
-              "#0e0e0e"
-            ],
-            [
-              9,
-              "#0e0e0e"
-            ],
-            [
-              11,
-              "#0e0e0e"
-            ],
-            [
-              13,
-              "#0e0e0e"
-            ],
-            [
-              15,
-              "#0e0e0e"
-            ]
+            [8, "#0e0e0e"],
+            [9, "#0e0e0e"],
+            [11, "#0e0e0e"],
+            [13, "#0e0e0e"],
+            [15, "#0e0e0e"]
           ]
         },
         "fill-antialias": true,
         "fill-opacity": {
           "stops": [
-            [
-              6,
-              0.7
-            ],
-            [
-              9,
-              0.9
-            ]
+            [6, 0.7],
+            [9, 0.9]
           ]
         }
       }
@@ -182,57 +105,23 @@
       "source": "carto",
       "source-layer": "landuse",
       "minzoom": 6,
-      "filter": [
-        "any",
-        [
-          "==",
-          "class",
-          "residential"
-        ]
-      ],
+      "filter": ["any", ["==", "class", "residential"]],
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              5,
-              "rgba(0, 0, 0, 0.5)"
-            ],
-            [
-              8,
-              "rgba(0, 0, 0, 0.45)"
-            ],
-            [
-              9,
-              "rgba(0, 0, 0, 0.4)"
-            ],
-            [
-              11,
-              "rgba(0, 0, 0, 0.35)"
-            ],
-            [
-              13,
-              "rgba(0, 0, 0, 0.3)"
-            ],
-            [
-              15,
-              "rgba(0, 0, 0, 0.25)"
-            ],
-            [
-              16,
-              "rgba(0, 0, 0, 0.15)"
-            ]
+            [5, "rgba(0, 0, 0, 0.5)"],
+            [8, "rgba(0, 0, 0, 0.45)"],
+            [9, "rgba(0, 0, 0, 0.4)"],
+            [11, "rgba(0, 0, 0, 0.35)"],
+            [13, "rgba(0, 0, 0, 0.3)"],
+            [15, "rgba(0, 0, 0, 0.25)"],
+            [16, "rgba(0, 0, 0, 0.15)"]
           ]
         },
         "fill-opacity": {
           "stops": [
-            [
-              6,
-              0.6
-            ],
-            [
-              9,
-              1
-            ]
+            [6, 0.6],
+            [9, 1]
           ]
         }
       }
@@ -242,42 +131,15 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "landuse",
-      "filter": [
-        "any",
-        [
-          "==",
-          "class",
-          "cemetery"
-        ],
-        [
-          "==",
-          "class",
-          "stadium"
-        ]
-      ],
+      "filter": ["any", ["==", "class", "cemetery"], ["==", "class", "stadium"]],
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              8,
-              "#0e0e0e"
-            ],
-            [
-              9,
-              "#0e0e0e"
-            ],
-            [
-              11,
-              "#0e0e0e"
-            ],
-            [
-              13,
-              "#0e0e0e"
-            ],
-            [
-              15,
-              "#0e0e0e"
-            ]
+            [8, "#0e0e0e"],
+            [9, "#0e0e0e"],
+            [11, "#0e0e0e"],
+            [13, "#0e0e0e"],
+            [15, "#0e0e0e"]
           ]
         }
       }
@@ -291,22 +153,10 @@
         "line-color": "#151515",
         "line-width": {
           "stops": [
-            [
-              8,
-              0.5
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              3
-            ]
+            [8, 0.5],
+            [9, 1],
+            [15, 2],
+            [16, 3]
           ]
         }
       }
@@ -318,63 +168,25 @@
       "source-layer": "boundary",
       "minzoom": 9,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          6
-        ],
-        [
-          "==",
-          "maritime",
-          0
-        ]
-      ],
+      "filter": ["all", ["==", "admin_level", 6], ["==", "maritime", 0]],
       "paint": {
         "line-color": {
           "stops": [
-            [
-              4,
-              "#222"
-            ],
-            [
-              5,
-              "#222"
-            ],
-            [
-              6,
-              "#292929"
-            ]
+            [4, "#222"],
+            [5, "#222"],
+            [6, "#292929"]
           ]
         },
         "line-width": {
           "stops": [
-            [
-              4,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [4, 0.5],
+            [7, 1]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [
-              6,
-              [
-                1
-              ]
-            ],
-            [
-              7,
-              [
-                2,
-                2
-              ]
-            ]
+            [6, [1]],
+            [7, [2, 2]]
           ]
         }
       }
@@ -385,71 +197,27 @@
       "source": "carto",
       "source-layer": "boundary",
       "minzoom": 4,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          4
-        ],
-        [
-          "==",
-          "maritime",
-          0
-        ]
-      ],
+      "filter": ["all", ["==", "admin_level", 4], ["==", "maritime", 0]],
       "paint": {
         "line-color": {
           "stops": [
-            [
-              4,
-              "#222"
-            ],
-            [
-              5,
-              "#222"
-            ],
-            [
-              6,
-              "#292929"
-            ]
+            [4, "#222"],
+            [5, "#222"],
+            [6, "#292929"]
           ]
         },
         "line-width": {
           "stops": [
-            [
-              4,
-              0.5
-            ],
-            [
-              7,
-              1
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              9,
-              1.2
-            ]
+            [4, 0.5],
+            [7, 1],
+            [8, 1],
+            [9, 1.2]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [
-              6,
-              [
-                1
-              ]
-            ],
-            [
-              7,
-              [
-                2,
-                2
-              ]
-            ]
+            [6, [1]],
+            [7, [2, 2]]
           ]
         }
       }
@@ -461,14 +229,7 @@
       "source-layer": "water",
       "minzoom": 0,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ]
-      ],
+      "filter": ["all", ["==", "$type", "Polygon"]],
       "layout": {
         "visibility": "visible"
       },
@@ -485,14 +246,7 @@
       "source": "carto",
       "source-layer": "water",
       "minzoom": 0,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ]
-      ],
+      "filter": ["all", ["==", "$type", "Polygon"]],
       "layout": {
         "visibility": "visible"
       },
@@ -503,34 +257,10 @@
         "fill-opacity": 1,
         "fill-translate": {
           "stops": [
-            [
-              0,
-              [
-                0,
-                2
-              ]
-            ],
-            [
-              6,
-              [
-                0,
-                1
-              ]
-            ],
-            [
-              14,
-              [
-                0,
-                1
-              ]
-            ],
-            [
-              17,
-              [
-                0,
-                2
-              ]
-            ]
+            [0, [0, 2]],
+            [6, [0, 1]],
+            [14, [0, 1]],
+            [17, [0, 2]]
           ]
         }
       }
@@ -541,40 +271,18 @@
       "source": "carto",
       "source-layer": "aeroway",
       "minzoom": 12,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "runway"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "runway"]],
       "layout": {
         "line-cap": "square"
       },
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ]
+            [11, 1],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10]
           ]
         },
         "line-color": "#111"
@@ -586,34 +294,15 @@
       "source": "carto",
       "source-layer": "aeroway",
       "minzoom": 13,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "taxiway"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "taxiway"]],
       "paint": {
         "line-color": "#111",
         "line-width": {
           "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              14,
-              1
-            ],
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              4
-            ]
+            [13, 0.5],
+            [14, 1],
+            [15, 2],
+            [16, 4]
           ]
         }
       }
@@ -625,19 +314,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -645,22 +322,10 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              17,
-              6
-            ],
-            [
-              18,
-              8
-            ]
+            [15, 1],
+            [16, 3],
+            [17, 6],
+            [18, 8]
           ]
         },
         "line-opacity": 1,
@@ -674,19 +339,7 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "miter"
@@ -694,34 +347,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              0.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 0.5],
+            [12, 0.5],
+            [14, 2],
+            [15, 4],
+            [16, 6],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
@@ -735,20 +367,7 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -756,38 +375,14 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 0.5],
+            [12, 1],
+            [13, 2],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -801,24 +396,7 @@
       "source-layer": "transportation",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round"
@@ -826,58 +404,22 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [5, 0.5],
+            [7, 1]
           ]
         },
         "line-color": "#1a1a1a"
@@ -890,24 +432,7 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -916,58 +441,22 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [5, 0.5],
+            [7, 1]
           ]
         },
         "line-color": "#232323"
@@ -982,21 +471,9 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
       "layout": {
         "line-cap": "butt",
@@ -1005,62 +482,23 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              12,
-              4
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              7
-            ],
-            [
-              15,
-              9
-            ],
-            [
-              16,
-              11
-            ],
-            [
-              17,
-              13
-            ],
-            [
-              18,
-              22
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [12, 4],
+            [13, 5],
+            [14, 7],
+            [15, 9],
+            [16, 11],
+            [17, 13],
+            [18, 22]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [6, 0.5],
+            [7, 1]
           ]
         },
         "line-color": "#232323"
@@ -1073,19 +511,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "path"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -1093,38 +519,17 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              18,
-              3
-            ]
+            [15, 0.5],
+            [16, 1],
+            [18, 3]
           ]
         },
         "line-opacity": 1,
         "line-color": "#262626",
         "line-dasharray": {
           "stops": [
-            [
-              15,
-              [
-                2,
-                2
-              ]
-            ],
-            [
-              18,
-              [
-                3,
-                3
-              ]
-            ]
+            [15, [2, 2]],
+            [18, [3, 3]]
           ]
         }
       }
@@ -1136,19 +541,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -1156,22 +549,10 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              17,
-              4
-            ],
-            [
-              18,
-              6
-            ]
+            [15, 2],
+            [16, 2],
+            [17, 4],
+            [18, 6]
           ]
         },
         "line-opacity": 1,
@@ -1185,19 +566,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round"
@@ -1205,22 +574,10 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              17,
-              8
-            ],
-            [
-              18,
-              12
-            ]
+            [15, 3],
+            [16, 4],
+            [17, 8],
+            [18, 12]
           ]
         },
         "line-opacity": 1,
@@ -1234,20 +591,7 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -1255,34 +599,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              3
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 2],
+            [13, 2],
+            [14, 3],
+            [15, 4],
+            [16, 6],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
@@ -1296,24 +619,7 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round"
@@ -1321,34 +627,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -1362,24 +647,7 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
@@ -1388,34 +656,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -1431,21 +678,9 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
       "layout": {
         "line-cap": "butt",
@@ -1454,38 +689,14 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              10,
-              1
-            ],
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              7
-            ],
-            [
-              16,
-              9
-            ],
-            [
-              17,
-              11
-            ],
-            [
-              18,
-              20
-            ]
+            [10, 1],
+            [12, 2],
+            [13, 3],
+            [14, 5],
+            [15, 7],
+            [16, 9],
+            [17, 11],
+            [18, 20]
           ]
         },
         "line-opacity": 1,
@@ -1498,19 +709,7 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
       "layout": {
         "visibility": "visible",
         "line-join": "round"
@@ -1520,26 +719,11 @@
         "line-width": {
           "base": 1.3,
           "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              14,
-              1
-            ],
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              21,
-              7
-            ]
+            [13, 0.5],
+            [14, 1],
+            [15, 1],
+            [16, 3],
+            [21, 7]
           ]
         },
         "line-opacity": 0.5
@@ -1551,19 +735,7 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 15,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
       "layout": {
         "visibility": "visible",
         "line-join": "round"
@@ -1573,36 +745,15 @@
         "line-width": {
           "base": 1.3,
           "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              20,
-              5
-            ]
+            [15, 0.5],
+            [16, 1],
+            [20, 5]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [
-              15,
-              [
-                5,
-                5
-              ]
-            ],
-            [
-              16,
-              [
-                6,
-                6
-              ]
-            ]
+            [15, [5, 5]],
+            [16, [6, 6]]
           ]
         },
         "line-opacity": 0.5
@@ -1615,18 +766,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -1634,22 +774,10 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              17,
-              6
-            ],
-            [
-              18,
-              8
-            ]
+            [15, 1],
+            [16, 3],
+            [17, 6],
+            [18, 8]
           ]
         },
         "line-opacity": 1,
@@ -1663,18 +791,7 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -1682,52 +799,22 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              0.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4.3
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 0.5],
+            [12, 0.5],
+            [14, 2],
+            [15, 3],
+            [16, 4.3],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [
-              13,
-              "#161616"
-            ],
-            [
-              15.7,
-              "#161616"
-            ],
-            [
-              16,
-              "#1c1c1c"
-            ]
+            [13, "#161616"],
+            [15.7, "#161616"],
+            [16, "#1c1c1c"]
           ]
         }
       }
@@ -1739,19 +826,7 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
+      "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -1759,42 +834,18 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              5
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ]
+            [12, 2],
+            [13, 3],
+            [14, 4],
+            [15, 5],
+            [16, 8],
+            [17, 10]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [5, 0.5],
+            [7, 1]
           ]
         },
         "line-color": "#232323"
@@ -1807,19 +858,7 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -1827,43 +866,19 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              5
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ]
+            [12, 2],
+            [13, 3],
+            [14, 4],
+            [15, 5],
+            [16, 8],
+            [17, 10]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [
-              12,
-              "#1a1a1a"
-            ],
-            [
-              14,
-              "#232323"
-            ]
+            [12, "#1a1a1a"],
+            [14, "#232323"]
           ]
         }
       }
@@ -1875,19 +890,7 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
+      "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -1895,43 +898,19 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              5
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ]
+            [12, 2],
+            [13, 3],
+            [14, 4],
+            [15, 5],
+            [16, 8],
+            [17, 10]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [
-              12,
-              "#1a1a1a"
-            ],
-            [
-              14,
-              "#232323"
-            ]
+            [12, "#1a1a1a"],
+            [14, "#232323"]
           ]
         }
       }
@@ -1943,19 +922,7 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -1963,55 +930,22 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              1.5
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 0.5],
+            [12, 1.5],
+            [13, 3],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [
-              11,
-              "#1a1a1a"
-            ],
-            [
-              12.99,
-              "#1a1a1a"
-            ],
-            [
-              13,
-              "#232323"
-            ]
+            [11, "#1a1a1a"],
+            [12.99, "#1a1a1a"],
+            [13, "#232323"]
           ]
         }
       }
@@ -2023,23 +957,7 @@
       "source-layer": "transportation",
       "minzoom": 7,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2047,70 +965,28 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [5, 0.5],
+            [7, 1]
           ]
         },
         "line-color": {
           "stops": [
-            [
-              7,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
+            [7, "#1a1a1a"],
+            [12, "#232323"]
           ]
         }
       }
@@ -2122,23 +998,7 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2146,70 +1006,28 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [5, 0.5],
+            [7, 1]
           ]
         },
         "line-color": {
           "stops": [
-            [
-              5,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
+            [5, "#1a1a1a"],
+            [12, "#232323"]
           ]
         }
       }
@@ -2221,23 +1039,7 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2245,74 +1047,29 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.7
-            ],
-            [
-              8,
-              0.8
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              12,
-              4
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              7
-            ],
-            [
-              15,
-              9
-            ],
-            [
-              16,
-              11
-            ],
-            [
-              17,
-              13
-            ],
-            [
-              18,
-              22
-            ]
+            [6, 0.5],
+            [7, 0.7],
+            [8, 0.8],
+            [11, 3],
+            [12, 4],
+            [13, 5],
+            [14, 7],
+            [15, 9],
+            [16, 11],
+            [17, 13],
+            [18, 22]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [6, 0.5],
+            [7, 1]
           ]
         },
         "line-color": {
           "stops": [
-            [
-              5,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
+            [5, "#1a1a1a"],
+            [12, "#232323"]
           ]
         }
       }
@@ -2324,19 +1081,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "path",
-          "track"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "path", "track"], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2344,38 +1089,17 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              18,
-              3
-            ]
+            [15, 0.5],
+            [16, 1],
+            [18, 3]
           ]
         },
         "line-opacity": 1,
         "line-color": "#262626",
         "line-dasharray": {
           "stops": [
-            [
-              15,
-              [
-                2,
-                2
-              ]
-            ],
-            [
-              18,
-              [
-                3,
-                3
-              ]
-            ]
+            [15, [2, 2]],
+            [18, [3, 3]]
           ]
         }
       }
@@ -2387,18 +1111,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2406,22 +1119,10 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              17,
-              4
-            ],
-            [
-              18,
-              6
-            ]
+            [15, 2],
+            [16, 2],
+            [17, 4],
+            [18, 6]
           ]
         },
         "line-opacity": 1,
@@ -2435,18 +1136,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2454,22 +1144,10 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              17,
-              8
-            ],
-            [
-              18,
-              12
-            ]
+            [15, 3],
+            [16, 4],
+            [17, 8],
+            [18, 12]
           ]
         },
         "line-opacity": 1,
@@ -2483,19 +1161,7 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
+      "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2503,30 +1169,12 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              8
-            ]
+            [12, 1],
+            [13, 1.5],
+            [14, 2],
+            [15, 3],
+            [16, 6],
+            [17, 8]
           ]
         },
         "line-opacity": 1,
@@ -2540,19 +1188,7 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
       "layout": {
         "line-cap": "square",
         "line-join": "round"
@@ -2560,30 +1196,12 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              8
-            ]
+            [12, 1],
+            [13, 1.5],
+            [14, 2],
+            [15, 3],
+            [16, 6],
+            [17, 8]
           ]
         },
         "line-opacity": 1,
@@ -2597,19 +1215,7 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
+      "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2617,30 +1223,12 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              8
-            ]
+            [12, 1],
+            [13, 1.5],
+            [14, 2],
+            [15, 3],
+            [16, 6],
+            [17, 8]
           ]
         },
         "line-opacity": 1,
@@ -2654,19 +1242,7 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2674,34 +1250,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              3
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 2],
+            [13, 2],
+            [14, 3],
+            [15, 4],
+            [16, 6],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
@@ -2715,23 +1270,7 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2739,34 +1278,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              10,
-              0.3
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [10, 0.3],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -2780,23 +1298,7 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2804,34 +1306,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -2845,23 +1326,7 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -2869,38 +1334,14 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              10,
-              1
-            ],
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              7
-            ],
-            [
-              16,
-              9
-            ],
-            [
-              17,
-              11
-            ],
-            [
-              18,
-              20
-            ]
+            [10, 1],
+            [12, 2],
+            [13, 3],
+            [14, 5],
+            [15, 7],
+            [16, 9],
+            [17, 11],
+            [18, 20]
           ]
         },
         "line-opacity": 1,
@@ -2913,19 +1354,7 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
       "layout": {
         "visibility": "visible",
         "line-join": "round"
@@ -2935,26 +1364,11 @@
         "line-width": {
           "base": 1.3,
           "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              14,
-              1
-            ],
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              21,
-              7
-            ]
+            [13, 0.5],
+            [14, 1],
+            [15, 1],
+            [16, 3],
+            [21, 7]
           ]
         }
       }
@@ -2965,19 +1379,7 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 15,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
       "layout": {
         "visibility": "visible",
         "line-join": "round"
@@ -2987,36 +1389,15 @@
         "line-width": {
           "base": 1.3,
           "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              20,
-              5
-            ]
+            [15, 0.5],
+            [16, 1],
+            [20, 5]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [
-              15,
-              [
-                5,
-                5
-              ]
-            ],
-            [
-              16,
-              [
-                6,
-                6
-              ]
-            ]
+            [15, [5, 5]],
+            [16, [6, 6]]
           ]
         }
       }
@@ -3028,19 +1409,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round"
@@ -3048,22 +1417,10 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              17,
-              6
-            ],
-            [
-              18,
-              8
-            ]
+            [15, 1],
+            [16, 3],
+            [17, 6],
+            [18, 8]
           ]
         },
         "line-opacity": 1,
@@ -3077,19 +1434,7 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "miter"
@@ -3097,52 +1442,22 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              0.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4.3
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 0.5],
+            [12, 0.5],
+            [14, 2],
+            [15, 3],
+            [16, 4.3],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [
-              13,
-              "#161616"
-            ],
-            [
-              15.7,
-              "#161616"
-            ],
-            [
-              16,
-              "#1c1c1c"
-            ]
+            [13, "#161616"],
+            [15.7, "#161616"],
+            [16, "#1c1c1c"]
           ]
         }
       }
@@ -3154,20 +1469,7 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "miter"
@@ -3175,55 +1477,22 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              1.5
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 0.5],
+            [12, 1.5],
+            [13, 3],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [
-              11,
-              "#1a1a1a"
-            ],
-            [
-              12.99,
-              "#1a1a1a"
-            ],
-            [
-              13,
-              "#232323"
-            ]
+            [11, "#1a1a1a"],
+            [12.99, "#1a1a1a"],
+            [13, "#232323"]
           ]
         }
       }
@@ -3235,24 +1504,7 @@
       "source-layer": "transportation",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round"
@@ -3260,70 +1512,28 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [5, 0.5],
+            [7, 1]
           ]
         },
         "line-color": {
           "stops": [
-            [
-              8,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
+            [8, "#1a1a1a"],
+            [12, "#232323"]
           ]
         }
       }
@@ -3335,24 +1545,7 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -3361,70 +1554,28 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [5, 0.5],
+            [7, 1]
           ]
         },
         "line-color": {
           "stops": [
-            [
-              5,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
+            [5, "#1a1a1a"],
+            [12, "#232323"]
           ]
         }
       }
@@ -3438,21 +1589,9 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
       "layout": {
         "line-cap": "butt",
@@ -3461,74 +1600,29 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              12,
-              4
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              7
-            ],
-            [
-              15,
-              9
-            ],
-            [
-              16,
-              11
-            ],
-            [
-              17,
-              13
-            ],
-            [
-              18,
-              22
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [12, 4],
+            [13, 5],
+            [14, 7],
+            [15, 9],
+            [16, 11],
+            [17, 13],
+            [18, 22]
           ]
         },
         "line-opacity": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
+            [6, 0.5],
+            [7, 1]
           ]
         },
         "line-color": {
           "stops": [
-            [
-              5,
-              "#1a1a1a"
-            ],
-            [
-              10,
-              "#232323"
-            ]
+            [5, "#1a1a1a"],
+            [10, "#232323"]
           ]
         }
       }
@@ -3540,19 +1634,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "path"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -3560,38 +1642,17 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              18,
-              3
-            ]
+            [15, 0.5],
+            [16, 1],
+            [18, 3]
           ]
         },
         "line-opacity": 1,
         "line-color": "#262626",
         "line-dasharray": {
           "stops": [
-            [
-              15,
-              [
-                2,
-                2
-              ]
-            ],
-            [
-              18,
-              [
-                3,
-                3
-              ]
-            ]
+            [15, [2, 2]],
+            [18, [3, 3]]
           ]
         }
       }
@@ -3603,19 +1664,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -3623,22 +1672,10 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              17,
-              4
-            ],
-            [
-              18,
-              6
-            ]
+            [15, 2],
+            [16, 2],
+            [17, 4],
+            [18, 6]
           ]
         },
         "line-opacity": 1,
@@ -3652,19 +1689,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round"
@@ -3672,22 +1697,10 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              17,
-              8
-            ],
-            [
-              18,
-              12
-            ]
+            [15, 3],
+            [16, 4],
+            [17, 8],
+            [18, 12]
           ]
         },
         "line-opacity": 1,
@@ -3701,20 +1714,7 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -3722,34 +1722,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              3
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 2],
+            [13, 2],
+            [14, 3],
+            [15, 4],
+            [16, 6],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
@@ -3763,24 +1742,7 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round"
@@ -3788,34 +1750,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -3829,24 +1770,7 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -3855,34 +1779,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -3898,21 +1801,9 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
       "layout": {
         "line-cap": "butt",
@@ -3921,38 +1812,14 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              10,
-              1
-            ],
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              7
-            ],
-            [
-              16,
-              9
-            ],
-            [
-              17,
-              11
-            ],
-            [
-              18,
-              20
-            ]
+            [10, 1],
+            [12, 2],
+            [13, 3],
+            [14, 5],
+            [15, 7],
+            [16, 9],
+            [17, 11],
+            [18, 20]
           ]
         },
         "line-opacity": 1,
@@ -3971,14 +1838,8 @@
         "fill-color": {
           "base": 1,
           "stops": [
-            [
-              15.5,
-              "transparent"
-            ],
-            [
-              16,
-              "transparent"
-            ]
+            [15.5, "transparent"],
+            [16, "transparent"]
           ]
         },
         "fill-antialias": true
@@ -3996,20 +1857,8 @@
         "fill-translate": {
           "base": 1,
           "stops": [
-            [
-              14,
-              [
-                0,
-                0
-              ]
-            ],
-            [
-              16,
-              [
-                -2,
-                -2
-              ]
-            ]
+            [14, [0, 0]],
+            [16, [-2, -2]]
           ]
         },
         "fill-outline-color": "#0e0e0e",
@@ -4017,14 +1866,8 @@
         "fill-opacity": {
           "base": 1,
           "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              16,
-              1
-            ]
+            [13, 0],
+            [16, 1]
           ]
         }
       }
@@ -4036,19 +1879,7 @@
       "source-layer": "boundary",
       "minzoom": 6,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          2
-        ],
-        [
-          "==",
-          "maritime",
-          0
-        ]
-      ],
+      "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -4066,19 +1897,7 @@
       "source": "carto",
       "source-layer": "boundary",
       "minzoom": 0,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          2
-        ],
-        [
-          "==",
-          "maritime",
-          0
-        ]
-      ],
+      "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
       "layout": {
         "line-cap": "round",
         "line-join": "round"
@@ -4086,31 +1905,16 @@
       "paint": {
         "line-color": {
           "stops": [
-            [
-              4,
-              "#222"
-            ],
-            [
-              5,
-              "#292929"
-            ],
-            [
-              6,
-              "#292929"
-            ]
+            [4, "#222"],
+            [5, "#292929"],
+            [6, "#292929"]
           ]
         },
         "line-opacity": 1,
         "line-width": {
           "stops": [
-            [
-              3,
-              1
-            ],
-            [
-              6,
-              1.5
-            ]
+            [3, 1],
+            [6, 1.5]
           ]
         },
         "line-offset": 0

--- a/mapboxgl/dark-matter-nolabels.json
+++ b/mapboxgl/dark-matter-nolabels.json
@@ -1,11 +1,11 @@
 {
   "version": 8,
   "name": "Dark Matter without labels",
-  "metadata": {},
+  "metadata": { "maputnik:renderer": "mbgljs" },
   "sources": {
     "carto": {
       "type": "vector",
-      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json{api_key}"
+      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json"
     }
   },
   "sprite": "https://tiles.basemaps.cartocdn.com/gl/dark-matter-gl-style/sprite",
@@ -14,13 +14,8 @@
     {
       "id": "background",
       "type": "background",
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "background-color": "#0e0e0e",
-        "background-opacity": 1
-      }
+      "layout": { "visibility": "visible" },
+      "paint": { "background-color": "#0e0e0e", "background-opacity": 1 }
     },
     {
       "id": "landcover",
@@ -53,9 +48,7 @@
       "source-layer": "park",
       "minzoom": 9,
       "filter": ["all", ["==", "class", "national_park"]],
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
           "stops": [
@@ -77,9 +70,7 @@
       "source-layer": "park",
       "minzoom": 0,
       "filter": ["all", ["==", "class", "nature_reserve"]],
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
           "stops": [
@@ -150,7 +141,7 @@
       "source": "carto",
       "source-layer": "waterway",
       "paint": {
-        "line-color": "#151515",
+        "line-color": "rgba(63, 90, 109, 1)",
         "line-width": {
           "stops": [
             [8, 0.5],
@@ -174,7 +165,7 @@
           "stops": [
             [4, "#222"],
             [5, "#222"],
-            [6, "#292929"]
+            [6, "#2C353C"]
           ]
         },
         "line-width": {
@@ -201,9 +192,9 @@
       "paint": {
         "line-color": {
           "stops": [
-            [4, "#222"],
-            [5, "#222"],
-            [6, "#292929"]
+            [4, "rgba(103, 103, 114, 1)"],
+            [5, "rgba(103, 103, 114, 1)"],
+            [6, "rgba(103, 103, 114, 1)"]
           ]
         },
         "line-width": {
@@ -216,8 +207,8 @@
         },
         "line-dasharray": {
           "stops": [
-            [6, [1]],
-            [7, [2, 2]]
+            [6, [1, 2, 3]],
+            [7, [1, 2, 3]]
           ]
         }
       }
@@ -230,11 +221,9 @@
       "minzoom": 0,
       "maxzoom": 24,
       "filter": ["all", ["==", "$type", "Polygon"]],
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": { "visibility": "visible" },
       "paint": {
-        "fill-color": "#212121",
+        "fill-color": "#2C353C",
         "fill-antialias": true,
         "fill-translate-anchor": "map",
         "fill-opacity": 1
@@ -247,9 +236,7 @@
       "source-layer": "water",
       "minzoom": 0,
       "filter": ["all", ["==", "$type", "Polygon"]],
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": "transparent",
         "fill-antialias": true,
@@ -272,9 +259,7 @@
       "source-layer": "aeroway",
       "minzoom": 12,
       "filter": ["all", ["==", "class", "runway"]],
-      "layout": {
-        "line-cap": "square"
-      },
+      "layout": { "line-cap": "square" },
       "paint": {
         "line-width": {
           "stops": [
@@ -315,10 +300,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -340,10 +322,7 @@
       "minzoom": 13,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter"
-      },
+      "layout": { "line-cap": "butt", "line-join": "miter" },
       "paint": {
         "line-width": {
           "stops": [
@@ -368,10 +347,7 @@
       "minzoom": 11,
       "maxzoom": 24,
       "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -397,10 +373,7 @@
       "minzoom": 8,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -475,10 +448,7 @@
         ["!=", "ramp", 1],
         ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -512,10 +482,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -542,10 +509,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -567,10 +531,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -592,10 +553,7 @@
       "minzoom": 13,
       "maxzoom": 24,
       "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -620,10 +578,7 @@
       "minzoom": 11,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -637,7 +592,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#161616"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -682,10 +637,7 @@
         ["!=", "ramp", 1],
         ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -700,7 +652,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#161616"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -710,10 +662,7 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round"
-      },
+      "layout": { "visibility": "visible", "line-join": "round" },
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
@@ -736,10 +685,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round"
-      },
+      "layout": { "visibility": "visible", "line-join": "round" },
       "paint": {
         "line-color": "#111",
         "line-width": {
@@ -767,10 +713,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -792,10 +735,7 @@
       "minzoom": 13,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -809,12 +749,11 @@
           ]
         },
         "line-opacity": 1,
-        "line-opacity": 1,
         "line-color": {
           "stops": [
-            [13, "#161616"],
-            [15.7, "#161616"],
-            [16, "#1c1c1c"]
+            [13, "rgba(65, 71, 88, 1)"],
+            [15.7, "rgba(65, 71, 88, 1)"],
+            [16, "rgba(65, 71, 88, 1)"]
           ]
         }
       }
@@ -827,10 +766,7 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -859,10 +795,7 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -891,10 +824,7 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -923,14 +853,11 @@
       "minzoom": 11,
       "maxzoom": 24,
       "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
+            [11, 0.9],
             [12, 1.5],
             [13, 3],
             [14, 5],
@@ -943,9 +870,9 @@
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [11, "#1a1a1a"],
-            [12.99, "#1a1a1a"],
-            [13, "#232323"]
+            [11, "rgba(65, 71, 88, 1)"],
+            [12.99, "rgba(65, 71, 88, 1)"],
+            [13, "rgba(65, 71, 88, 1)"]
           ]
         }
       }
@@ -958,10 +885,7 @@
       "minzoom": 7,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -999,10 +923,7 @@
       "minzoom": 5,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1040,10 +961,7 @@
       "minzoom": 5,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1082,10 +1000,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["in", "class", "path", "track"], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1112,10 +1027,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1137,10 +1049,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1151,7 +1060,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -1162,10 +1071,7 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1189,10 +1095,7 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
-      "layout": {
-        "line-cap": "square",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "square", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1216,10 +1119,7 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1232,7 +1132,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -1243,10 +1143,7 @@
       "minzoom": 13,
       "maxzoom": 24,
       "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1260,7 +1157,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -1271,10 +1168,7 @@
       "minzoom": 10,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1288,7 +1182,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(83, 86, 102, 1)"
       }
     },
     {
@@ -1299,10 +1193,7 @@
       "minzoom": 10,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1316,7 +1207,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -1327,10 +1218,7 @@
       "minzoom": 10,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1345,7 +1233,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(73, 73, 73, 1)"
       }
     },
     {
@@ -1355,10 +1243,7 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round"
-      },
+      "layout": { "visibility": "visible", "line-join": "round" },
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
@@ -1380,10 +1265,7 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round"
-      },
+      "layout": { "visibility": "visible", "line-join": "round" },
       "paint": {
         "line-color": "#111",
         "line-width": {
@@ -1410,10 +1292,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1435,10 +1314,7 @@
       "minzoom": 13,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter"
-      },
+      "layout": { "line-cap": "butt", "line-join": "miter" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1451,7 +1327,6 @@
             [18, 14]
           ]
         },
-        "line-opacity": 1,
         "line-opacity": 1,
         "line-color": {
           "stops": [
@@ -1470,10 +1345,7 @@
       "minzoom": 11,
       "maxzoom": 24,
       "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter"
-      },
+      "layout": { "line-cap": "butt", "line-join": "miter" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1505,10 +1377,7 @@
       "minzoom": 8,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1593,10 +1462,7 @@
         ["!=", "ramp", 1],
         ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1635,10 +1501,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1665,10 +1528,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1690,10 +1550,7 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1715,10 +1572,7 @@
       "minzoom": 13,
       "maxzoom": 24,
       "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1743,10 +1597,7 @@
       "minzoom": 11,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1789,7 +1640,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -1805,10 +1656,7 @@
         ["!=", "ramp", 1],
         ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1823,7 +1671,7 @@
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -1831,9 +1679,7 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
           "base": 1,
@@ -1850,9 +1696,7 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-translate": {
           "base": 1,
@@ -1862,7 +1706,7 @@
           ]
         },
         "fill-outline-color": "#0e0e0e",
-        "fill-color": "#000",
+        "fill-color": "rgba(57, 57, 57, 1)",
         "fill-opacity": {
           "base": 1,
           "stops": [
@@ -1880,12 +1724,9 @@
       "minzoom": 6,
       "maxzoom": 24,
       "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-color": "#0e0e0e",
+        "line-color": "#2C353C",
         "line-opacity": 0.5,
         "line-width": 8,
         "line-offset": 0
@@ -1898,16 +1739,13 @@
       "source-layer": "boundary",
       "minzoom": 0,
       "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-color": {
           "stops": [
-            [4, "#222"],
-            [5, "#292929"],
-            [6, "#292929"]
+            [4, "rgba(92, 94, 94, 1)"],
+            [5, "rgba(96, 96, 96, 1)"],
+            [6, "rgba(102, 102, 102, 1)"]
           ]
         },
         "line-opacity": 1,

--- a/mapboxgl/dark-matter.json
+++ b/mapboxgl/dark-matter.json
@@ -1,11 +1,11 @@
 {
   "version": 8,
   "name": "Dark Matter",
-  "metadata": {},
+  "metadata": {"maputnik:renderer": "mbgljs"},
   "sources": {
     "carto": {
       "type": "vector",
-      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json{api_key}"
+      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json"
     }
   },
   "sprite": "https://tiles.basemaps.cartocdn.com/gl/dark-matter-gl-style/sprite",
@@ -14,13 +14,8 @@
     {
       "id": "background",
       "type": "background",
-      "layout": {
-        "visibility": "visible"
-      },
-      "paint": {
-        "background-color": "#0e0e0e",
-        "background-opacity": 1
-      }
+      "layout": {"visibility": "visible"},
+      "paint": {"background-color": "#0e0e0e", "background-opacity": 1}
     },
     {
       "id": "landcover",
@@ -29,45 +24,18 @@
       "source-layer": "landcover",
       "filter": [
         "any",
-        [
-          "==",
-          "class",
-          "wood"
-        ],
-        [
-          "==",
-          "class",
-          "grass"
-        ],
-        [
-          "==",
-          "subclass",
-          "recreation_ground"
-        ]
+        ["==", "class", "wood"],
+        ["==", "class", "grass"],
+        ["==", "subclass", "recreation_ground"]
       ],
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              8,
-              "#0e0e0e"
-            ],
-            [
-              9,
-              "#0e0e0e"
-            ],
-            [
-              11,
-              "#0e0e0e"
-            ],
-            [
-              13,
-              "#0e0e0e"
-            ],
-            [
-              15,
-              "#0e0e0e"
-            ]
+            [8, "#0e0e0e"],
+            [9, "#0e0e0e"],
+            [11, "#0e0e0e"],
+            [13, "#0e0e0e"],
+            [15, "#0e0e0e"]
           ]
         },
         "fill-opacity": 1
@@ -79,40 +47,16 @@
       "source": "carto",
       "source-layer": "park",
       "minzoom": 9,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "national_park"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "class", "national_park"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              8,
-              "#0e0e0e"
-            ],
-            [
-              9,
-              "#0e0e0e"
-            ],
-            [
-              11,
-              "#0e0e0e"
-            ],
-            [
-              13,
-              "#0e0e0e"
-            ],
-            [
-              15,
-              "#0e0e0e"
-            ]
+            [8, "#0e0e0e"],
+            [9, "#0e0e0e"],
+            [11, "#0e0e0e"],
+            [13, "#0e0e0e"],
+            [15, "#0e0e0e"]
           ]
         },
         "fill-opacity": 1,
@@ -125,55 +69,20 @@
       "source": "carto",
       "source-layer": "park",
       "minzoom": 0,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "nature_reserve"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "class", "nature_reserve"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              8,
-              "#0e0e0e"
-            ],
-            [
-              9,
-              "#0e0e0e"
-            ],
-            [
-              11,
-              "#0e0e0e"
-            ],
-            [
-              13,
-              "#0e0e0e"
-            ],
-            [
-              15,
-              "#0e0e0e"
-            ]
+            [8, "#0e0e0e"],
+            [9, "#0e0e0e"],
+            [11, "#0e0e0e"],
+            [13, "#0e0e0e"],
+            [15, "#0e0e0e"]
           ]
         },
         "fill-antialias": true,
-        "fill-opacity": {
-          "stops": [
-            [
-              6,
-              0.7
-            ],
-            [
-              9,
-              0.9
-            ]
-          ]
-        }
+        "fill-opacity": {"stops": [[6, 0.7], [9, 0.9]]}
       }
     },
     {
@@ -182,59 +91,20 @@
       "source": "carto",
       "source-layer": "landuse",
       "minzoom": 6,
-      "filter": [
-        "any",
-        [
-          "==",
-          "class",
-          "residential"
-        ]
-      ],
+      "filter": ["any", ["==", "class", "residential"]],
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              5,
-              "rgba(0, 0, 0, 0.5)"
-            ],
-            [
-              8,
-              "rgba(0, 0, 0, 0.45)"
-            ],
-            [
-              9,
-              "rgba(0, 0, 0, 0.4)"
-            ],
-            [
-              11,
-              "rgba(0, 0, 0, 0.35)"
-            ],
-            [
-              13,
-              "rgba(0, 0, 0, 0.3)"
-            ],
-            [
-              15,
-              "rgba(0, 0, 0, 0.25)"
-            ],
-            [
-              16,
-              "rgba(0, 0, 0, 0.15)"
-            ]
+            [5, "rgba(0, 0, 0, 0.5)"],
+            [8, "rgba(0, 0, 0, 0.45)"],
+            [9, "rgba(0, 0, 0, 0.4)"],
+            [11, "rgba(0, 0, 0, 0.35)"],
+            [13, "rgba(0, 0, 0, 0.3)"],
+            [15, "rgba(0, 0, 0, 0.25)"],
+            [16, "rgba(0, 0, 0, 0.15)"]
           ]
         },
-        "fill-opacity": {
-          "stops": [
-            [
-              6,
-              0.6
-            ],
-            [
-              9,
-              1
-            ]
-          ]
-        }
+        "fill-opacity": {"stops": [[6, 0.6], [9, 1]]}
       }
     },
     {
@@ -244,40 +114,17 @@
       "source-layer": "landuse",
       "filter": [
         "any",
-        [
-          "==",
-          "class",
-          "cemetery"
-        ],
-        [
-          "==",
-          "class",
-          "stadium"
-        ]
+        ["==", "class", "cemetery"],
+        ["==", "class", "stadium"]
       ],
       "paint": {
         "fill-color": {
           "stops": [
-            [
-              8,
-              "#0e0e0e"
-            ],
-            [
-              9,
-              "#0e0e0e"
-            ],
-            [
-              11,
-              "#0e0e0e"
-            ],
-            [
-              13,
-              "#0e0e0e"
-            ],
-            [
-              15,
-              "#0e0e0e"
-            ]
+            [8, "#0e0e0e"],
+            [9, "#0e0e0e"],
+            [11, "#0e0e0e"],
+            [13, "#0e0e0e"],
+            [15, "#0e0e0e"]
           ]
         }
       }
@@ -288,27 +135,8 @@
       "source": "carto",
       "source-layer": "waterway",
       "paint": {
-        "line-color": "#151515",
-        "line-width": {
-          "stops": [
-            [
-              8,
-              0.5
-            ],
-            [
-              9,
-              1
-            ],
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              3
-            ]
-          ]
-        }
+        "line-color": "rgba(63, 90, 109, 1)",
+        "line-width": {"stops": [[8, 0.5], [9, 1], [15, 2], [16, 3]]}
       }
     },
     {
@@ -318,65 +146,11 @@
       "source-layer": "boundary",
       "minzoom": 9,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          6
-        ],
-        [
-          "==",
-          "maritime",
-          0
-        ]
-      ],
+      "filter": ["all", ["==", "admin_level", 6], ["==", "maritime", 0]],
       "paint": {
-        "line-color": {
-          "stops": [
-            [
-              4,
-              "#222"
-            ],
-            [
-              5,
-              "#222"
-            ],
-            [
-              6,
-              "#292929"
-            ]
-          ]
-        },
-        "line-width": {
-          "stops": [
-            [
-              4,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
-        "line-dasharray": {
-          "stops": [
-            [
-              6,
-              [
-                1
-              ]
-            ],
-            [
-              7,
-              [
-                2,
-                2
-              ]
-            ]
-          ]
-        }
+        "line-color": {"stops": [[4, "#222"], [5, "#222"], [6, "#2C353C"]]},
+        "line-width": {"stops": [[4, 0.5], [7, 1]]},
+        "line-dasharray": {"stops": [[6, [1]], [7, [2, 2]]]}
       }
     },
     {
@@ -385,73 +159,17 @@
       "source": "carto",
       "source-layer": "boundary",
       "minzoom": 4,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          4
-        ],
-        [
-          "==",
-          "maritime",
-          0
-        ]
-      ],
+      "filter": ["all", ["==", "admin_level", 4], ["==", "maritime", 0]],
       "paint": {
         "line-color": {
           "stops": [
-            [
-              4,
-              "#222"
-            ],
-            [
-              5,
-              "#222"
-            ],
-            [
-              6,
-              "#292929"
-            ]
+            [4, "rgba(103, 103, 114, 1)"],
+            [5, "rgba(103, 103, 114, 1)"],
+            [6, "rgba(103, 103, 114, 1)"]
           ]
         },
-        "line-width": {
-          "stops": [
-            [
-              4,
-              0.5
-            ],
-            [
-              7,
-              1
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              9,
-              1.2
-            ]
-          ]
-        },
-        "line-dasharray": {
-          "stops": [
-            [
-              6,
-              [
-                1
-              ]
-            ],
-            [
-              7,
-              [
-                2,
-                2
-              ]
-            ]
-          ]
-        }
+        "line-width": {"stops": [[4, 0.5], [7, 1], [8, 1], [9, 1.2]]},
+        "line-dasharray": {"stops": [[6, [1, 2, 3]], [7, [1, 2, 3]]]}
       }
     },
     {
@@ -461,19 +179,10 @@
       "source-layer": "water",
       "minzoom": 0,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "$type", "Polygon"]],
+      "layout": {"visibility": "visible"},
       "paint": {
-        "fill-color": "#212121",
+        "fill-color": "#2C353C",
         "fill-antialias": true,
         "fill-translate-anchor": "map",
         "fill-opacity": 1
@@ -485,53 +194,15 @@
       "source": "carto",
       "source-layer": "water",
       "minzoom": 0,
-      "filter": [
-        "all",
-        [
-          "==",
-          "$type",
-          "Polygon"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible"
-      },
+      "filter": ["all", ["==", "$type", "Polygon"]],
+      "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": "transparent",
         "fill-antialias": true,
         "fill-translate-anchor": "map",
         "fill-opacity": 1,
         "fill-translate": {
-          "stops": [
-            [
-              0,
-              [
-                0,
-                2
-              ]
-            ],
-            [
-              6,
-              [
-                0,
-                1
-              ]
-            ],
-            [
-              14,
-              [
-                0,
-                1
-              ]
-            ],
-            [
-              17,
-              [
-                0,
-                2
-              ]
-            ]
-          ]
+          "stops": [[0, [0, 2]], [6, [0, 1]], [14, [0, 1]], [17, [0, 2]]]
         }
       }
     },
@@ -541,42 +212,10 @@
       "source": "carto",
       "source-layer": "aeroway",
       "minzoom": 12,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "runway"
-        ]
-      ],
-      "layout": {
-        "line-cap": "square"
-      },
+      "filter": ["all", ["==", "class", "runway"]],
+      "layout": {"line-cap": "square"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ]
-          ]
-        },
+        "line-width": {"stops": [[11, 1], [13, 4], [14, 6], [15, 8], [16, 10]]},
         "line-color": "#111"
       }
     },
@@ -586,36 +225,10 @@
       "source": "carto",
       "source-layer": "aeroway",
       "minzoom": 13,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "taxiway"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "taxiway"]],
       "paint": {
         "line-color": "#111",
-        "line-width": {
-          "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              14,
-              1
-            ],
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              4
-            ]
-          ]
-        }
+        "line-width": {"stops": [[13, 0.5], [14, 1], [15, 2], [16, 4]]}
       }
     },
     {
@@ -623,18 +236,7 @@
       "type": "symbol",
       "source": "carto",
       "source-layer": "waterway",
-      "filter": [
-        "all",
-        [
-          "has",
-          "name"
-        ],
-        [
-          "==",
-          "class",
-          "river"
-        ]
-      ],
+      "filter": ["all", ["has", "name"], ["==", "class", "river"]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -647,51 +249,18 @@
         "symbol-placement": "line",
         "symbol-spacing": 300,
         "symbol-avoid-edges": false,
-        "text-size": {
-          "stops": [
-            [
-              9,
-              8
-            ],
-            [
-              10,
-              9
-            ]
-          ]
-        },
+        "text-size": {"stops": [[9, 8], [10, 9]]},
         "text-padding": 2,
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
         "text-offset": {
-          "stops": [
-            [
-              6,
-              [
-                0,
-                -0.2
-              ]
-            ],
-            [
-              11,
-              [
-                0,
-                -0.4
-              ]
-            ],
-            [
-              12,
-              [
-                0,
-                -0.6
-              ]
-            ]
-          ]
+          "stops": [[6, [0, -0.2]], [11, [0, -0.4]], [12, [0, -0.6]]]
         },
         "text-letter-spacing": 0,
         "text-keep-upright": true
       },
       "paint": {
-        "text-color": "#444",
+        "text-color": "rgba(164, 164, 164, 1)",
         "text-halo-color": "#181818",
         "text-halo-width": 1
       }
@@ -705,42 +274,12 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "service"],
+        ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              17,
-              6
-            ],
-            [
-              18,
-              8
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 1], [16, 3], [17, 6], [18, 8]]},
         "line-opacity": 1,
         "line-color": "#1a1a1a"
       }
@@ -752,54 +291,18 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter"
-      },
+      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
+      "layout": {"line-cap": "butt", "line-join": "miter"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              0.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 0.5],
+            [12, 0.5],
+            [14, 2],
+            [15, 4],
+            [16, 6],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
@@ -815,57 +318,21 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["in", "class", "secondary", "tertiary"],
+        ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 0.5],
+            [12, 1],
+            [13, 2],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -881,83 +348,27 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "primary"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
+        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
         "line-color": "#1a1a1a"
       }
     },
@@ -970,21 +381,9 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "trunk"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
       "layout": {
         "line-cap": "butt",
@@ -994,60 +393,19 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
+        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
         "line-color": "#232323"
       }
     },
@@ -1060,87 +418,28 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              12,
-              4
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              7
-            ],
-            [
-              15,
-              9
-            ],
-            [
-              16,
-              11
-            ],
-            [
-              17,
-              13
-            ],
-            [
-              18,
-              22
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [12, 4],
+            [13, 5],
+            [14, 7],
+            [15, 9],
+            [16, 11],
+            [17, 13],
+            [18, 22]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
+        "line-opacity": {"stops": [[6, 0.5], [7, 1]]},
         "line-color": "#232323"
       }
     },
@@ -1151,60 +450,13 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "path"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "tunnel"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              18,
-              3
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 0.5], [16, 1], [18, 3]]},
         "line-opacity": 1,
         "line-color": "#262626",
-        "line-dasharray": {
-          "stops": [
-            [
-              15,
-              [
-                2,
-                2
-              ]
-            ],
-            [
-              18,
-              [
-                3,
-                3
-              ]
-            ]
-          ]
-        }
+        "line-dasharray": {"stops": [[15, [2, 2]], [18, [3, 3]]]}
       }
     },
     {
@@ -1216,42 +468,12 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "service"],
+        ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              17,
-              4
-            ],
-            [
-              18,
-              6
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 2], [16, 2], [17, 4], [18, 6]]},
         "line-opacity": 1,
         "line-color": "#161616"
       }
@@ -1263,46 +485,12 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              17,
-              8
-            ],
-            [
-              18,
-              12
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 3], [16, 4], [17, 8], [18, 12]]},
         "line-opacity": 1,
-        "line-color": "rgba(22, 22, 22, 1)"
+        "line-color": "rgba(238, 238, 238, 1)"
       }
     },
     {
@@ -1314,53 +502,20 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["in", "class", "secondary", "tertiary"],
+        ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              3
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 2],
+            [13, 2],
+            [14, 3],
+            [15, 4],
+            [16, 6],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
@@ -1376,61 +531,25 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "primary"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
-        "line-color": "#161616"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -1442,21 +561,9 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "trunk"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
       "layout": {
         "line-cap": "round",
@@ -1466,34 +573,13 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -1509,65 +595,26 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "tunnel"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              10,
-              1
-            ],
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              7
-            ],
-            [
-              16,
-              9
-            ],
-            [
-              17,
-              11
-            ],
-            [
-              18,
-              20
-            ]
+            [10, 1],
+            [12, 2],
+            [13, 3],
+            [14, 5],
+            [15, 7],
+            [16, 9],
+            [17, 11],
+            [18, 20]
           ]
         },
         "line-opacity": 1,
-        "line-color": "#161616"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -1576,49 +623,13 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
+      "layout": {"visibility": "visible", "line-join": "round"},
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
           "base": 1.3,
-          "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              14,
-              1
-            ],
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              21,
-              7
-            ]
-          ]
+          "stops": [[13, 0.5], [14, 1], [15, 1], [16, 3], [21, 7]]
         },
         "line-opacity": 0.5
       }
@@ -1629,60 +640,12 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 15,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "==",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
+      "layout": {"visibility": "visible", "line-join": "round"},
       "paint": {
         "line-color": "#111",
-        "line-width": {
-          "base": 1.3,
-          "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              20,
-              5
-            ]
-          ]
-        },
-        "line-dasharray": {
-          "stops": [
-            [
-              15,
-              [
-                5,
-                5
-              ]
-            ],
-            [
-              16,
-              [
-                6,
-                6
-              ]
-            ]
-          ]
-        },
+        "line-width": {"base": 1.3, "stops": [[15, 0.5], [16, 1], [20, 5]]},
+        "line-dasharray": {"stops": [[15, [5, 5]], [16, [6, 6]]]},
         "line-opacity": 0.5
       }
     },
@@ -1693,43 +656,10 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              17,
-              6
-            ],
-            [
-              18,
-              8
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 1], [16, 3], [17, 6], [18, 8]]},
         "line-opacity": 1,
         "line-color": "#1c1c1c"
       }
@@ -1741,71 +671,26 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              0.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4.3
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 0.5],
+            [12, 0.5],
+            [14, 2],
+            [15, 3],
+            [16, 4.3],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
-        "line-opacity": 1,
         "line-color": {
           "stops": [
-            [
-              13,
-              "#161616"
-            ],
-            [
-              15.7,
-              "#161616"
-            ],
-            [
-              16,
-              "#1c1c1c"
-            ]
+            [13, "rgba(65, 71, 88, 1)"],
+            [15.7, "rgba(65, 71, 88, 1)"],
+            [16, "rgba(65, 71, 88, 1)"]
           ]
         }
       }
@@ -1817,64 +702,13 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
-          "stops": [
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              5
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ]
-          ]
+          "stops": [[12, 2], [13, 3], [14, 4], [15, 5], [16, 8], [17, 10]]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
+        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
         "line-color": "#232323"
       }
     },
@@ -1885,65 +719,14 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
-          "stops": [
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              5
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ]
-          ]
+          "stops": [[12, 2], [13, 3], [14, 4], [15, 5], [16, 8], [17, 10]]
         },
         "line-opacity": 1,
-        "line-color": {
-          "stops": [
-            [
-              12,
-              "#1a1a1a"
-            ],
-            [
-              14,
-              "#232323"
-            ]
-          ]
-        }
+        "line-color": {"stops": [[12, "#1a1a1a"], [14, "#232323"]]}
       }
     },
     {
@@ -1953,65 +736,14 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
-          "stops": [
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              5
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              10
-            ]
-          ]
+          "stops": [[12, 2], [13, 3], [14, 4], [15, 5], [16, 8], [17, 10]]
         },
         "line-opacity": 1,
-        "line-color": {
-          "stops": [
-            [
-              12,
-              "#1a1a1a"
-            ],
-            [
-              14,
-              "#232323"
-            ]
-          ]
-        }
+        "line-color": {"stops": [[12, "#1a1a1a"], [14, "#232323"]]}
       }
     },
     {
@@ -2023,73 +755,29 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
+        ["in", "class", "secondary", "tertiary"],
+        ["!has", "brunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              1.5
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 0.9],
+            [12, 1.5],
+            [13, 3],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [
-              11,
-              "#1a1a1a"
-            ],
-            [
-              12.99,
-              "#1a1a1a"
-            ],
-            [
-              13,
-              "#232323"
-            ]
+            [11, "rgba(65, 71, 88, 1)"],
+            [12.99, "rgba(65, 71, 88, 1)"],
+            [13, "rgba(65, 71, 88, 1)"]
           ]
         }
       }
@@ -2103,94 +791,28 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
+        ["==", "class", "primary"],
+        ["!=", "ramp", 1],
+        ["!has", "brunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
-        "line-color": {
-          "stops": [
-            [
-              7,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
-          ]
-        }
+        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
+        "line-color": {"stops": [[7, "#1a1a1a"], [12, "#232323"]]}
       }
     },
     {
@@ -2202,94 +824,28 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
+        ["==", "class", "trunk"],
+        ["!=", "ramp", 1],
+        ["!has", "brunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
-        "line-color": {
-          "stops": [
-            [
-              5,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
-          ]
-        }
+        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
+        "line-color": {"stops": [[5, "#1a1a1a"], [12, "#232323"]]}
       }
     },
     {
@@ -2301,98 +857,29 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["!has", "brunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.7
-            ],
-            [
-              8,
-              0.8
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              12,
-              4
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              7
-            ],
-            [
-              15,
-              9
-            ],
-            [
-              16,
-              11
-            ],
-            [
-              17,
-              13
-            ],
-            [
-              18,
-              22
-            ]
+            [6, 0.5],
+            [7, 0.7],
+            [8, 0.8],
+            [11, 3],
+            [12, 4],
+            [13, 5],
+            [14, 7],
+            [15, 9],
+            [16, 11],
+            [17, 13],
+            [18, 22]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
-        "line-color": {
-          "stops": [
-            [
-              5,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
-          ]
-        }
+        "line-opacity": {"stops": [[6, 0.5], [7, 1]]},
+        "line-color": {"stops": [[5, "#1a1a1a"], [12, "#232323"]]}
       }
     },
     {
@@ -2402,60 +889,13 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "path",
-          "track"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["in", "class", "path", "track"], ["!has", "brunnel"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              18,
-              3
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 0.5], [16, 1], [18, 3]]},
         "line-opacity": 1,
         "line-color": "#262626",
-        "line-dasharray": {
-          "stops": [
-            [
-              15,
-              [
-                2,
-                2
-              ]
-            ],
-            [
-              18,
-              [
-                3,
-                3
-              ]
-            ]
-          ]
-        }
+        "line-dasharray": {"stops": [[15, [2, 2]], [18, [3, 3]]]}
       }
     },
     {
@@ -2465,43 +905,10 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              17,
-              4
-            ],
-            [
-              18,
-              6
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 2], [16, 2], [17, 4], [18, 6]]},
         "line-opacity": 1,
         "line-color": "#0b0b0b"
       }
@@ -2513,45 +920,12 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              17,
-              8
-            ],
-            [
-              18,
-              12
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 3], [16, 4], [17, 8], [18, 12]]},
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -2561,51 +935,11 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
-          "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              8
-            ]
-          ]
+          "stops": [[12, 1], [13, 1.5], [14, 2], [15, 3], [16, 6], [17, 8]]
         },
         "line-opacity": 1,
         "line-color": "#0b0b0b"
@@ -2618,51 +952,11 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
-      "layout": {
-        "line-cap": "square",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
+      "layout": {"line-cap": "square", "line-join": "round"},
       "paint": {
         "line-width": {
-          "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              8
-            ]
-          ]
+          "stops": [[12, 1], [13, 1.5], [14, 2], [15, 3], [16, 6], [17, 8]]
         },
         "line-opacity": 1,
         "line-color": "#0b0b0b"
@@ -2675,54 +969,14 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "==",
-          "ramp",
-          1
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
-          "stops": [
-            [
-              12,
-              1
-            ],
-            [
-              13,
-              1.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              8
-            ]
-          ]
+          "stops": [[12, 1], [13, 1.5], [14, 2], [15, 3], [16, 6], [17, 8]]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -2734,56 +988,24 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
+        ["in", "class", "secondary", "tertiary"],
+        ["!has", "brunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              3
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 2],
+            [13, 2],
+            [14, 3],
+            [15, 4],
+            [16, 6],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -2795,60 +1017,25 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
+        ["==", "class", "primary"],
+        ["!=", "ramp", 1],
+        ["!has", "brunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              10,
-              0.3
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [10, 0.3],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(83, 86, 102, 1)"
       }
     },
     {
@@ -2860,60 +1047,25 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
+        ["==", "class", "trunk"],
+        ["!=", "ramp", 1],
+        ["!has", "brunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -2925,64 +1077,26 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "!has",
-          "brunnel"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["!has", "brunnel"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              10,
-              1
-            ],
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              7
-            ],
-            [
-              16,
-              9
-            ],
-            [
-              17,
-              11
-            ],
-            [
-              18,
-              20
-            ]
+            [10, 1],
+            [12, 2],
+            [13, 3],
+            [14, 5],
+            [15, 7],
+            [16, 9],
+            [17, 11],
+            [18, 20]
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(73, 73, 73, 1)"
       }
     },
     {
@@ -2991,49 +1105,13 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
+      "layout": {"visibility": "visible", "line-join": "round"},
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
           "base": 1.3,
-          "stops": [
-            [
-              13,
-              0.5
-            ],
-            [
-              14,
-              1
-            ],
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              21,
-              7
-            ]
-          ]
+          "stops": [[13, 0.5], [14, 1], [15, 1], [16, 3], [21, 7]]
         }
       }
     },
@@ -3043,60 +1121,12 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 15,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "rail"
-        ],
-        [
-          "!=",
-          "brunnel",
-          "tunnel"
-        ]
-      ],
-      "layout": {
-        "visibility": "visible",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
+      "layout": {"visibility": "visible", "line-join": "round"},
       "paint": {
         "line-color": "#111",
-        "line-width": {
-          "base": 1.3,
-          "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              20,
-              5
-            ]
-          ]
-        },
-        "line-dasharray": {
-          "stops": [
-            [
-              15,
-              [
-                5,
-                5
-              ]
-            ],
-            [
-              16,
-              [
-                6,
-                6
-              ]
-            ]
-          ]
-        }
+        "line-width": {"base": 1.3, "stops": [[15, 0.5], [16, 1], [20, 5]]},
+        "line-dasharray": {"stops": [[15, [5, 5]], [16, [6, 6]]]}
       }
     },
     {
@@ -3108,42 +1138,12 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "service"],
+        ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              1
-            ],
-            [
-              16,
-              3
-            ],
-            [
-              17,
-              6
-            ],
-            [
-              18,
-              8
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 1], [16, 3], [17, 6], [18, 8]]},
         "line-opacity": 1,
         "line-color": "#1c1c1c"
       }
@@ -3155,73 +1155,23 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter"
-      },
+      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
+      "layout": {"line-cap": "butt", "line-join": "miter"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              0.5
-            ],
-            [
-              14,
-              2
-            ],
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4.3
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 0.5],
+            [12, 0.5],
+            [14, 2],
+            [15, 3],
+            [16, 4.3],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
-        "line-opacity": 1,
         "line-color": {
-          "stops": [
-            [
-              13,
-              "#161616"
-            ],
-            [
-              15.7,
-              "#161616"
-            ],
-            [
-              16,
-              "#1c1c1c"
-            ]
-          ]
+          "stops": [[13, "#161616"], [15.7, "#161616"], [16, "#1c1c1c"]]
         }
       }
     },
@@ -3234,75 +1184,26 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["in", "class", "secondary", "tertiary"],
+        ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "miter"
-      },
+      "layout": {"line-cap": "butt", "line-join": "miter"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              0.5
-            ],
-            [
-              12,
-              1.5
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 0.5],
+            [12, 1.5],
+            [13, 3],
+            [14, 5],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
         "line-color": {
-          "stops": [
-            [
-              11,
-              "#1a1a1a"
-            ],
-            [
-              12.99,
-              "#1a1a1a"
-            ],
-            [
-              13,
-              "#232323"
-            ]
-          ]
+          "stops": [[11, "#1a1a1a"], [12.99, "#1a1a1a"], [13, "#232323"]]
         }
       }
     },
@@ -3315,95 +1216,28 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "primary"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
-        "line-color": {
-          "stops": [
-            [
-              8,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
-          ]
-        }
+        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
+        "line-color": {"stops": [[8, "#1a1a1a"], [12, "#232323"]]}
       }
     },
     {
@@ -3415,21 +1249,9 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "trunk"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
       "layout": {
         "line-cap": "butt",
@@ -3439,72 +1261,20 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              13,
-              4
-            ],
-            [
-              14,
-              6
-            ],
-            [
-              15,
-              8
-            ],
-            [
-              16,
-              10
-            ],
-            [
-              17,
-              14
-            ],
-            [
-              18,
-              18
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10],
+            [17, 14],
+            [18, 18]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              5,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
-        "line-color": {
-          "stops": [
-            [
-              5,
-              "#1a1a1a"
-            ],
-            [
-              12,
-              "#232323"
-            ]
-          ]
-        }
+        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
+        "line-color": {"stops": [[5, "#1a1a1a"], [12, "#232323"]]}
       }
     },
     {
@@ -3516,99 +1286,29 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              0.8
-            ],
-            [
-              8,
-              1
-            ],
-            [
-              11,
-              3
-            ],
-            [
-              12,
-              4
-            ],
-            [
-              13,
-              5
-            ],
-            [
-              14,
-              7
-            ],
-            [
-              15,
-              9
-            ],
-            [
-              16,
-              11
-            ],
-            [
-              17,
-              13
-            ],
-            [
-              18,
-              22
-            ]
+            [6, 0.5],
+            [7, 0.8],
+            [8, 1],
+            [11, 3],
+            [12, 4],
+            [13, 5],
+            [14, 7],
+            [15, 9],
+            [16, 11],
+            [17, 13],
+            [18, 22]
           ]
         },
-        "line-opacity": {
-          "stops": [
-            [
-              6,
-              0.5
-            ],
-            [
-              7,
-              1
-            ]
-          ]
-        },
-        "line-color": {
-          "stops": [
-            [
-              5,
-              "#1a1a1a"
-            ],
-            [
-              10,
-              "#232323"
-            ]
-          ]
-        }
+        "line-opacity": {"stops": [[6, 0.5], [7, 1]]},
+        "line-color": {"stops": [[5, "#1a1a1a"], [10, "#232323"]]}
       }
     },
     {
@@ -3618,60 +1318,13 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "path"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "bridge"]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              0.5
-            ],
-            [
-              16,
-              1
-            ],
-            [
-              18,
-              3
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 0.5], [16, 1], [18, 3]]},
         "line-opacity": 1,
         "line-color": "#262626",
-        "line-dasharray": {
-          "stops": [
-            [
-              15,
-              [
-                2,
-                2
-              ]
-            ],
-            [
-              18,
-              [
-                3,
-                3
-              ]
-            ]
-          ]
-        }
+        "line-dasharray": {"stops": [[15, [2, 2]], [18, [3, 3]]]}
       }
     },
     {
@@ -3683,42 +1336,12 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "service"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "service"],
+        ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              2
-            ],
-            [
-              16,
-              2
-            ],
-            [
-              17,
-              4
-            ],
-            [
-              18,
-              6
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 2], [16, 2], [17, 4], [18, 6]]},
         "line-opacity": 1,
         "line-color": "#0b0b0b"
       }
@@ -3730,44 +1353,10 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "minor"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
-      ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
-        "line-width": {
-          "stops": [
-            [
-              15,
-              3
-            ],
-            [
-              16,
-              4
-            ],
-            [
-              17,
-              8
-            ],
-            [
-              18,
-              12
-            ]
-          ]
-        },
+        "line-width": {"stops": [[15, 3], [16, 4], [17, 8], [18, 12]]},
         "line-opacity": 1,
         "line-color": "#0b0b0b"
       }
@@ -3781,53 +1370,20 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["in", "class", "secondary", "tertiary"],
+        ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              2
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              3
-            ],
-            [
-              15,
-              4
-            ],
-            [
-              16,
-              6
-            ],
-            [
-              17,
-              10
-            ],
-            [
-              18,
-              14
-            ]
+            [11, 2],
+            [13, 2],
+            [14, 3],
+            [15, 4],
+            [16, 6],
+            [17, 10],
+            [18, 14]
           ]
         },
         "line-opacity": 1,
@@ -3843,57 +1399,21 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "primary"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "primary"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
@@ -3909,21 +1429,9 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "trunk"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "trunk"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
       "layout": {
         "line-cap": "butt",
@@ -3933,38 +1441,17 @@
       "paint": {
         "line-width": {
           "stops": [
-            [
-              11,
-              1
-            ],
-            [
-              13,
-              2
-            ],
-            [
-              14,
-              4
-            ],
-            [
-              15,
-              6
-            ],
-            [
-              16,
-              8
-            ],
-            [
-              17,
-              12
-            ],
-            [
-              18,
-              16
-            ]
+            [11, 1],
+            [13, 2],
+            [14, 4],
+            [15, 6],
+            [16, 8],
+            [17, 12],
+            [18, 16]
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -3976,65 +1463,26 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "motorway"
-        ],
-        [
-          "!=",
-          "ramp",
-          1
-        ],
-        [
-          "==",
-          "brunnel",
-          "bridge"
-        ]
+        ["==", "class", "motorway"],
+        ["!=", "ramp", 1],
+        ["==", "brunnel", "bridge"]
       ],
-      "layout": {
-        "line-cap": "butt",
-        "line-join": "round"
-      },
+      "layout": {"line-cap": "butt", "line-join": "round"},
       "paint": {
         "line-width": {
           "stops": [
-            [
-              10,
-              1
-            ],
-            [
-              12,
-              2
-            ],
-            [
-              13,
-              3
-            ],
-            [
-              14,
-              5
-            ],
-            [
-              15,
-              7
-            ],
-            [
-              16,
-              9
-            ],
-            [
-              17,
-              11
-            ],
-            [
-              18,
-              20
-            ]
+            [10, 1],
+            [12, 2],
+            [13, 3],
+            [14, 5],
+            [15, 7],
+            [16, 9],
+            [17, 11],
+            [18, 20]
           ]
         },
         "line-opacity": 1,
-        "line-color": "#0b0b0b"
+        "line-color": "rgba(65, 71, 88, 1)"
       }
     },
     {
@@ -4042,22 +1490,11 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "visible"},
       "paint": {
         "fill-color": {
           "base": 1,
-          "stops": [
-            [
-              15.5,
-              "transparent"
-            ],
-            [
-              16,
-              "transparent"
-            ]
-          ]
+          "stops": [[15.5, "transparent"], [16, "transparent"]]
         },
         "fill-antialias": true
       }
@@ -4067,44 +1504,12 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": {
-        "visibility": "visible"
-      },
+      "layout": {"visibility": "visible"},
       "paint": {
-        "fill-translate": {
-          "base": 1,
-          "stops": [
-            [
-              14,
-              [
-                0,
-                0
-              ]
-            ],
-            [
-              16,
-              [
-                -2,
-                -2
-              ]
-            ]
-          ]
-        },
+        "fill-translate": {"base": 1, "stops": [[14, [0, 0]], [16, [-2, -2]]]},
         "fill-outline-color": "#0e0e0e",
-        "fill-color": "#000",
-        "fill-opacity": {
-          "base": 1,
-          "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              16,
-              1
-            ]
-          ]
-        }
+        "fill-color": "rgba(57, 57, 57, 1)",
+        "fill-opacity": {"base": 1, "stops": [[13, 0], [16, 1]]}
       }
     },
     {
@@ -4114,25 +1519,10 @@
       "source-layer": "boundary",
       "minzoom": 6,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          2
-        ],
-        [
-          "==",
-          "maritime",
-          0
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
-        "line-color": "#0e0e0e",
+        "line-color": "#2C353C",
         "line-opacity": 0.5,
         "line-width": 8,
         "line-offset": 0
@@ -4144,53 +1534,18 @@
       "source": "carto",
       "source-layer": "boundary",
       "minzoom": 0,
-      "filter": [
-        "all",
-        [
-          "==",
-          "admin_level",
-          2
-        ],
-        [
-          "==",
-          "maritime",
-          0
-        ]
-      ],
-      "layout": {
-        "line-cap": "round",
-        "line-join": "round"
-      },
+      "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
+      "layout": {"line-cap": "round", "line-join": "round"},
       "paint": {
         "line-color": {
           "stops": [
-            [
-              4,
-              "#222"
-            ],
-            [
-              5,
-              "#292929"
-            ],
-            [
-              6,
-              "#292929"
-            ]
+            [4, "rgba(92, 94, 94, 1)"],
+            [5, "rgba(96, 96, 96, 1)"],
+            [6, "rgba(102, 102, 102, 1)"]
           ]
         },
         "line-opacity": 1,
-        "line-width": {
-          "stops": [
-            [
-              3,
-              1
-            ],
-            [
-              6,
-              1.5
-            ]
-          ]
-        },
+        "line-width": {"stops": [[3, 1], [6, 1.5]]},
         "line-offset": 0
       }
     },
@@ -4203,40 +1558,14 @@
       "maxzoom": 5,
       "filter": [
         "all",
-        [
-          "has",
-          "name"
-        ],
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "==",
-          "class",
-          "ocean"
-        ]
+        ["has", "name"],
+        ["==", "$type", "Point"],
+        ["==", "class", "ocean"]
       ],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "point",
-        "text-size": {
-          "stops": [
-            [
-              0,
-              13
-            ],
-            [
-              2,
-              14
-            ],
-            [
-              4,
-              18
-            ]
-          ]
-        },
+        "text-size": {"stops": [[0, 13], [2, 14], [4, 18]]},
         "text-font": [
           "Montserrat Medium Italic",
           "Open Sans Italic",
@@ -4254,7 +1583,7 @@
         "text-letter-spacing": 0.1
       },
       "paint": {
-        "text-color": "#3c3c3c",
+        "text-color": "rgba(109, 123, 129, 1)",
         "text-halo-color": "rgba(0,0,0,0.7)",
         "text-halo-width": 1,
         "text-halo-blur": 0
@@ -4268,20 +1597,9 @@
       "minzoom": 5,
       "filter": [
         "all",
-        [
-          "has",
-          "name"
-        ],
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "==",
-          "class",
-          "sea"
-        ]
+        ["has", "name"],
+        ["==", "$type", "Point"],
+        ["==", "class", "sea"]
       ],
       "layout": {
         "text-field": "{name}",
@@ -4318,58 +1636,15 @@
       "minzoom": 4,
       "filter": [
         "all",
-        [
-          "has",
-          "name"
-        ],
-        [
-          "==",
-          "$type",
-          "Point"
-        ],
-        [
-          "==",
-          "class",
-          "lake"
-        ]
+        ["has", "name"],
+        ["==", "$type", "Point"],
+        ["==", "class", "lake"]
       ],
       "layout": {
-        "text-field": {
-          "stops": [
-            [
-              8,
-              "{name_en}"
-            ],
-            [
-              13,
-              "{name}"
-            ]
-          ]
-        },
+        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
         "symbol-placement": "point",
         "text-size": {
-          "stops": [
-            [
-              13,
-              9
-            ],
-            [
-              14,
-              10
-            ],
-            [
-              15,
-              11
-            ],
-            [
-              16,
-              12
-            ],
-            [
-              17,
-              13
-            ]
-          ]
+          "stops": [[13, 9], [14, 10], [15, 11], [16, 12], [17, 13]]
         },
         "text-font": [
           "Montserrat Regular Italic",
@@ -4386,7 +1661,7 @@
         "text-rotation-alignment": "auto"
       },
       "paint": {
-        "text-color": "#444",
+        "text-color": "rgba(155, 155, 155, 1)",
         "text-halo-color": "#181818",
         "text-halo-width": 1,
         "text-halo-blur": 1
@@ -4397,55 +1672,12 @@
       "type": "symbol",
       "source": "carto",
       "source-layer": "water_name",
-      "filter": [
-        "all",
-        [
-          "has",
-          "name"
-        ],
-        [
-          "==",
-          "$type",
-          "LineString"
-        ]
-      ],
+      "filter": ["all", ["has", "name"], ["==", "$type", "LineString"]],
       "layout": {
-        "text-field": {
-          "stops": [
-            [
-              8,
-              "{name_en}"
-            ],
-            [
-              13,
-              "{name}"
-            ]
-          ]
-        },
+        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
         "symbol-placement": "line",
         "text-size": {
-          "stops": [
-            [
-              13,
-              9
-            ],
-            [
-              14,
-              10
-            ],
-            [
-              15,
-              11
-            ],
-            [
-              16,
-              12
-            ],
-            [
-              17,
-              13
-            ]
-          ]
+          "stops": [[13, 9], [14, 10], [15, 11], [16, 12], [17, 13]]
         },
         "text-font": [
           "Montserrat Regular Italic",
@@ -4475,30 +1707,11 @@
       "maxzoom": 16,
       "filter": [
         "any",
-        [
-          "==",
-          "class",
-          "neighbourhood"
-        ],
-        [
-          "==",
-          "class",
-          "hamlet"
-        ]
+        ["==", "class", "neighbourhood"],
+        ["==", "class", "hamlet"]
       ],
       "layout": {
-        "text-field": {
-          "stops": [
-            [
-              8,
-              "{name_en}"
-            ],
-            [
-              14,
-              "{name}"
-            ]
-          ]
-        },
+        "text-field": {"stops": [[8, "{name_en}"], [14, "{name}"]]},
         "text-font": [
           "Montserrat Regular",
           "Open Sans Regular",
@@ -4506,53 +1719,21 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              13,
-              8
-            ],
-            [
-              14,
-              10
-            ],
-            [
-              16,
-              11
-            ]
-          ]
-        },
+        "text-size": {"stops": [[13, 8], [14, 10], [16, 11]]},
         "icon-image": "",
-        "icon-offset": [
-          16,
-          0
-        ],
+        "icon-offset": [16, 0],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ],
-        "text-transform": {
-          "stops": [
-            [
-              12,
-              "none"
-            ],
-            [
-              14,
-              "uppercase"
-            ]
-          ]
-        }
+        "text-offset": [0.2, 0.2],
+        "text-transform": {"stops": [[12, "none"], [14, "uppercase"]]}
       },
       "paint": {
-        "text-color": "#666",
+        "text-color": "rgba(182, 180, 180, 1)",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
-        "text-halo-color": "#222",
+        "text-halo-color": "rgba(53, 52, 52, 1)",
         "text-halo-width": 1
       }
     },
@@ -4563,27 +1744,9 @@
       "source-layer": "place",
       "minzoom": 12,
       "maxzoom": 16,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "suburb"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "suburb"]],
       "layout": {
-        "text-field": {
-          "stops": [
-            [
-              8,
-              "{name_en}"
-            ],
-            [
-              13,
-              "{name}"
-            ]
-          ]
-        },
+        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
         "text-font": [
           "Montserrat Regular",
           "Open Sans Regular",
@@ -4592,54 +1755,16 @@
           "NanumBarunGothic Regular"
         ],
         "text-size": {
-          "stops": [
-            [
-              12,
-              9
-            ],
-            [
-              13,
-              10
-            ],
-            [
-              14,
-              11
-            ],
-            [
-              15,
-              12
-            ],
-            [
-              16,
-              13
-            ]
-          ]
+          "stops": [[12, 9], [13, 10], [14, 11], [15, 12], [16, 13]]
         },
         "icon-image": "",
-        "icon-offset": [
-          16,
-          0
-        ],
+        "icon-offset": [16, 0],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ],
-        "text-transform": {
-          "stops": [
-            [
-              8,
-              "none"
-            ],
-            [
-              12,
-              "uppercase"
-            ]
-          ]
-        }
+        "text-offset": [0.2, 0.2],
+        "text-transform": {"stops": [[8, "none"], [12, "uppercase"]]}
       },
       "paint": {
         "text-color": "#666",
@@ -4656,27 +1781,9 @@
       "source-layer": "place",
       "minzoom": 10,
       "maxzoom": 16,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "village"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "village"]],
       "layout": {
-        "text-field": {
-          "stops": [
-            [
-              8,
-              "{name_en}"
-            ],
-            [
-              13,
-              "{name}"
-            ]
-          ]
-        },
+        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
         "text-font": [
           "Montserrat Medium",
           "Open Sans Bold",
@@ -4685,46 +1792,19 @@
           "NanumBarunGothic Regular"
         ],
         "text-size": {
-          "stops": [
-            [
-              10,
-              9
-            ],
-            [
-              12,
-              10
-            ],
-            [
-              13,
-              11
-            ],
-            [
-              14,
-              12
-            ],
-            [
-              16,
-              13
-            ]
-          ]
+          "stops": [[10, 9], [12, 10], [13, 11], [14, 12], [16, 13]]
         },
         "icon-image": "",
-        "icon-offset": [
-          16,
-          0
-        ],
+        "icon-offset": [16, 0],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ],
+        "text-offset": [0.2, 0.2],
         "text-transform": "none"
       },
       "paint": {
-        "text-color": "#666",
+        "text-color": "rgba(154, 153, 153, 1)",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -4738,27 +1818,9 @@
       "source-layer": "place",
       "minzoom": 8,
       "maxzoom": 14,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "town"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "town"]],
       "layout": {
-        "text-field": {
-          "stops": [
-            [
-              8,
-              "{name_en}"
-            ],
-            [
-              13,
-              "{name}"
-            ]
-          ]
-        },
+        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
         "text-font": [
           "Montserrat Medium",
           "Open Sans Bold",
@@ -4767,46 +1829,19 @@
           "NanumBarunGothic Regular"
         ],
         "text-size": {
-          "stops": [
-            [
-              8,
-              10
-            ],
-            [
-              9,
-              10
-            ],
-            [
-              10,
-              11
-            ],
-            [
-              13,
-              14
-            ],
-            [
-              14,
-              15
-            ]
-          ]
+          "stops": [[8, 10], [9, 10], [10, 11], [13, 14], [14, 15]]
         },
         "icon-image": "",
-        "icon-offset": [
-          16,
-          0
-        ],
+        "icon-offset": [16, 0],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ],
+        "text-offset": [0.2, 0.2],
         "text-transform": "none"
       },
       "paint": {
-        "text-color": "#666",
+        "text-color": "rgba(204, 208, 228, 1)",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -4822,20 +1857,9 @@
       "maxzoom": 10,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "country"
-        ],
-        [
-          ">=",
-          "rank",
-          3
-        ],
-        [
-          "has",
-          "iso_a2"
-        ]
+        ["==", "class", "country"],
+        [">=", "rank", 3],
+        ["has", "iso_a2"]
       ],
       "layout": {
         "text-field": "{name_en}",
@@ -4846,47 +1870,15 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              3,
-              10
-            ],
-            [
-              5,
-              11
-            ],
-            [
-              6,
-              12
-            ],
-            [
-              7,
-              13
-            ],
-            [
-              8,
-              14
-            ]
-          ]
-        },
+        "text-size": {"stops": [[3, 10], [5, 11], [6, 12], [7, 13], [8, 14]]},
         "text-transform": "uppercase"
       },
       "paint": {
         "text-color": {
           "stops": [
-            [
-              3,
-              "#555"
-            ],
-            [
-              5,
-              "#444"
-            ],
-            [
-              6,
-              "#3a3a3a"
-            ]
+            [3, "rgba(157, 157, 157, 1)"],
+            [5, "rgba(114, 114, 114, 1)"],
+            [6, "rgba(112, 112, 112, 1)"]
           ]
         },
         "text-halo-color": "#111",
@@ -4900,19 +1892,7 @@
       "source-layer": "place",
       "minzoom": 2,
       "maxzoom": 7,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "country"
-        ],
-        [
-          "<=",
-          "rank",
-          2
-        ]
-      ],
+      "filter": ["all", ["==", "class", "country"], ["<=", "rank", 2]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -4922,63 +1902,16 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              3,
-              11
-            ],
-            [
-              4,
-              12
-            ],
-            [
-              5,
-              13
-            ],
-            [
-              6,
-              14
-            ]
-          ]
-        },
+        "text-size": {"stops": [[3, 11], [4, 12], [5, 13], [6, 14]]},
         "text-transform": "uppercase",
-        "text-max-width": {
-          "stops": [
-            [
-              2,
-              6
-            ],
-            [
-              3,
-              6
-            ],
-            [
-              4,
-              9
-            ],
-            [
-              5,
-              12
-            ]
-          ]
-        }
+        "text-max-width": {"stops": [[2, 6], [3, 6], [4, 9], [5, 12]]}
       },
       "paint": {
         "text-color": {
           "stops": [
-            [
-              3,
-              "#555"
-            ],
-            [
-              5,
-              "#444"
-            ],
-            [
-              6,
-              "#3a3a3a"
-            ]
+            [3, "rgba(158, 182, 189, 1)"],
+            [5, "rgba(118, 126, 137, 1)"],
+            [6, "rgba(120, 141, 147, 1)"]
           ]
         },
         "text-halo-color": "#111",
@@ -4992,19 +1925,7 @@
       "source-layer": "place",
       "minzoom": 5,
       "maxzoom": 10,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "state"
-        ],
-        [
-          "<=",
-          "rank",
-          4
-        ]
-      ],
+      "filter": ["all", ["==", "class", "state"], ["<=", "rank", 4]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -5014,23 +1935,12 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              5,
-              12
-            ],
-            [
-              7,
-              14
-            ]
-          ]
-        },
+        "text-size": {"stops": [[5, 12], [7, 14]]},
         "text-transform": "uppercase",
         "text-max-width": 9
       },
       "paint": {
-        "text-color": "#444",
+        "text-color": "rgba(203, 230, 230, 1)",
         "text-halo-color": "#111",
         "text-halo-width": 0
       }
@@ -5042,14 +1952,7 @@
       "source-layer": "place",
       "minzoom": 0,
       "maxzoom": 2,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "continent"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "continent"]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -5067,7 +1970,7 @@
         "text-keep-upright": false
       },
       "paint": {
-        "text-color": "#555",
+        "text-color": "rgba(135, 164, 179, 1)",
         "text-halo-color": "#111",
         "text-halo-width": 1
       }
@@ -5079,32 +1982,9 @@
       "source-layer": "place",
       "minzoom": 8,
       "maxzoom": 15,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          ">=",
-          "rank",
-          6
-        ]
-      ],
+      "filter": ["all", ["==", "class", "city"], [">=", "rank", 6]],
       "layout": {
-        "text-field": {
-          "stops": [
-            [
-              8,
-              "{name_en}"
-            ],
-            [
-              13,
-              "{name}"
-            ]
-          ]
-        },
+        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
         "text-font": [
           "Montserrat Medium",
           "Open Sans Bold",
@@ -5113,46 +1993,19 @@
           "NanumBarunGothic Regular"
         ],
         "text-size": {
-          "stops": [
-            [
-              8,
-              12
-            ],
-            [
-              9,
-              13
-            ],
-            [
-              10,
-              14
-            ],
-            [
-              13,
-              17
-            ],
-            [
-              14,
-              20
-            ]
-          ]
+          "stops": [[8, 12], [9, 13], [10, 14], [13, 17], [14, 20]]
         },
         "icon-image": "",
-        "icon-offset": [
-          16,
-          0
-        ],
+        "icon-offset": [16, 0],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ],
+        "text-offset": [0.2, 0.2],
         "text-transform": "uppercase"
       },
       "paint": {
-        "text-color": "#666",
+        "text-color": "rgba(168, 176, 180, 1)",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -5168,35 +2021,12 @@
       "maxzoom": 15,
       "filter": [
         "all",
-        [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          ">=",
-          "rank",
-          0
-        ],
-        [
-          "<=",
-          "rank",
-          5
-        ]
+        ["==", "class", "city"],
+        [">=", "rank", 0],
+        ["<=", "rank", 5]
       ],
       "layout": {
-        "text-field": {
-          "stops": [
-            [
-              8,
-              "{name_en}"
-            ],
-            [
-              13,
-              "{name}"
-            ]
-          ]
-        },
+        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
         "text-font": [
           "Montserrat Medium",
           "Open Sans Bold",
@@ -5204,43 +2034,18 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              8,
-              14
-            ],
-            [
-              10,
-              16
-            ],
-            [
-              13,
-              19
-            ],
-            [
-              14,
-              22
-            ]
-          ]
-        },
+        "text-size": {"stops": [[8, 14], [10, 16], [13, 19], [14, 22]]},
         "icon-image": "",
-        "icon-offset": [
-          16,
-          0
-        ],
+        "icon-offset": [16, 0],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ],
+        "text-offset": [0.2, 0.2],
         "text-transform": "uppercase"
       },
       "paint": {
-        "text-color": "#666",
+        "text-color": "rgba(211, 228, 236, 1)",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -5254,19 +2059,7 @@
       "source-layer": "place",
       "minzoom": 6,
       "maxzoom": 7,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          "<=",
-          "rank",
-          7
-        ]
-      ],
+      "filter": ["all", ["==", "class", "city"], ["<=", "rank", 7]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -5278,22 +2071,16 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [
-          16,
-          5
-        ],
+        "icon-offset": [16, 5],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ]
+        "text-offset": [0.2, 0.2]
       },
       "paint": {
-        "text-color": "#666",
-        "icon-color": "#666",
+        "text-color": "rgba(174, 191, 207, 1)",
+        "icon-color": "rgba(94, 105, 106, 1)",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
         "text-halo-width": 1
@@ -5306,19 +2093,7 @@
       "source-layer": "place",
       "minzoom": 5,
       "maxzoom": 7,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          "<=",
-          "rank",
-          4
-        ]
-      ],
+      "filter": ["all", ["==", "class", "city"], ["<=", "rank", 4]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -5330,21 +2105,15 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [
-          16,
-          5
-        ],
+        "icon-offset": [16, 5],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ]
+        "text-offset": [0.2, 0.2]
       },
       "paint": {
-        "text-color": "#666",
+        "text-color": "rgba(233, 239, 246, 1)",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -5358,19 +2127,7 @@
       "source-layer": "place",
       "minzoom": 4,
       "maxzoom": 7,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "city"
-        ],
-        [
-          "<=",
-          "rank",
-          2
-        ]
-      ],
+      "filter": ["all", ["==", "class", "city"], ["<=", "rank", 2]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -5382,22 +2139,16 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [
-          16,
-          5
-        ],
+        "icon-offset": [16, 5],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ]
+        "text-offset": [0.2, 0.2]
       },
       "paint": {
-        "text-color": "#666",
-        "icon-color": "#666",
+        "text-color": "rgba(175, 194, 217, 1)",
+        "icon-color": "rgba(131, 164, 189, 1)",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
         "text-halo-width": 1
@@ -5412,16 +2163,8 @@
       "maxzoom": 8,
       "filter": [
         "all",
-        [
-          "!has",
-          "capital"
-        ],
-        [
-          "!in",
-          "class",
-          "country",
-          "state"
-        ]
+        ["!has", "capital"],
+        ["!in", "class", "country", "state"]
       ],
       "layout": {
         "text-field": "{name_en}",
@@ -5434,22 +2177,16 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [
-          16,
-          5
-        ],
+        "icon-offset": [16, 5],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ]
+        "text-offset": [0.2, 0.2]
       },
       "paint": {
-        "text-color": "#666",
-        "icon-color": "#666",
+        "text-color": "rgba(160, 179, 191, 1)",
+        "icon-color": "rgba(113, 128, 147, 1)",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
         "text-halo-width": 1
@@ -5462,14 +2199,7 @@
       "source-layer": "place",
       "minzoom": 7,
       "maxzoom": 8,
-      "filter": [
-        "all",
-        [
-          ">",
-          "capital",
-          0
-        ]
-      ],
+      "filter": ["all", [">", "capital", 0]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -5481,22 +2211,16 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [
-          16,
-          5
-        ],
+        "icon-offset": [16, 5],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [
-          0.2,
-          0.2
-        ],
+        "text-offset": [0.2, 0.2],
         "text-transform": "uppercase"
       },
       "paint": {
-        "text-color": "#666",
+        "text-color": "rgba(177, 201, 214, 1)",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -5511,18 +2235,8 @@
       "minzoom": 15,
       "filter": [
         "all",
-        [
-          "in",
-          "class",
-          "stadium",
-          "cemetery",
-          "attraction"
-        ],
-        [
-          "<=",
-          "rank",
-          3
-        ]
+        ["in", "class", "stadium", "cemetery", "attraction"],
+        ["<=", "rank", 3]
       ],
       "layout": {
         "text-field": "{name}",
@@ -5533,22 +2247,7 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              15,
-              8
-            ],
-            [
-              17,
-              9
-            ],
-            [
-              18,
-              10
-            ]
-          ]
-        },
+        "text-size": {"stops": [[15, 8], [17, 9], [18, 10]]},
         "text-transform": "uppercase"
       },
       "paint": {
@@ -5563,14 +2262,7 @@
       "source": "carto",
       "source-layer": "poi",
       "minzoom": 15,
-      "filter": [
-        "all",
-        [
-          "==",
-          "class",
-          "park"
-        ]
-      ],
+      "filter": ["all", ["==", "class", "park"]],
       "layout": {
         "text-field": "{name}",
         "text-font": [
@@ -5580,22 +2272,7 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              15,
-              8
-            ],
-            [
-              17,
-              9
-            ],
-            [
-              18,
-              10
-            ]
-          ]
-        },
+        "text-size": {"stops": [[15, 8], [17, 9], [18, 10]]},
         "text-transform": "uppercase"
       },
       "paint": {
@@ -5610,15 +2287,7 @@
       "source": "carto",
       "source-layer": "transportation_name",
       "minzoom": 16,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "minor",
-          "service"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "minor", "service"]],
       "layout": {
         "symbol-placement": "line",
         "text-font": [
@@ -5637,7 +2306,7 @@
         "text-justify": "center"
       },
       "paint": {
-        "text-color": "#383838",
+        "text-color": "rgba(181, 180, 180, 1)",
         "text-halo-color": "#111",
         "text-halo-width": 1
       }
@@ -5648,15 +2317,7 @@
       "source": "carto",
       "source-layer": "transportation_name",
       "minzoom": 15,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "secondary",
-          "tertiary"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "secondary", "tertiary"]],
       "layout": {
         "symbol-placement": "line",
         "text-font": [
@@ -5666,22 +2327,7 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              15,
-              9
-            ],
-            [
-              16,
-              11
-            ],
-            [
-              18,
-              12
-            ]
-          ]
-        },
+        "text-size": {"stops": [[15, 9], [16, 11], [18, 12]]},
         "text-field": "{name}",
         "symbol-avoid-edges": false,
         "symbol-spacing": 200,
@@ -5690,8 +2336,8 @@
         "text-justify": "center"
       },
       "paint": {
-        "text-color": "#383838",
-        "text-halo-color": "#111",
+        "text-color": "rgba(146, 146, 146, 1)",
+        "text-halo-color": "rgba(34, 34, 34, 1)",
         "text-halo-width": 1
       }
     },
@@ -5701,14 +2347,7 @@
       "source": "carto",
       "source-layer": "transportation_name",
       "minzoom": 14,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "primary"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "primary"]],
       "layout": {
         "symbol-placement": "line",
         "text-font": [
@@ -5718,58 +2357,17 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              14,
-              10
-            ],
-            [
-              15,
-              10
-            ],
-            [
-              16,
-              11
-            ],
-            [
-              18,
-              12
-            ]
-          ]
-        },
+        "text-size": {"stops": [[14, 10], [15, 10], [16, 11], [18, 12]]},
         "text-field": "{name}",
         "symbol-avoid-edges": false,
-        "symbol-spacing": {
-          "stops": [
-            [
-              6,
-              200
-            ],
-            [
-              16,
-              250
-            ]
-          ]
-        },
+        "symbol-spacing": {"stops": [[6, 200], [16, 250]]},
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
         "text-justify": "center",
-        "text-letter-spacing": {
-          "stops": [
-            [
-              14,
-              0
-            ],
-            [
-              16,
-              0.2
-            ]
-          ]
-        }
+        "text-letter-spacing": {"stops": [[14, 0], [16, 0.2]]}
       },
       "paint": {
-        "text-color": "#383838",
+        "text-color": "rgba(189, 189, 189, 1)",
         "text-halo-color": "#111",
         "text-halo-width": 1
       }
@@ -5780,15 +2378,7 @@
       "source": "carto",
       "source-layer": "transportation_name",
       "minzoom": 13,
-      "filter": [
-        "all",
-        [
-          "in",
-          "class",
-          "trunk",
-          "motorway"
-        ]
-      ],
+      "filter": ["all", ["in", "class", "trunk", "motorway"]],
       "layout": {
         "symbol-placement": "line",
         "text-font": [
@@ -5798,55 +2388,14 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {
-          "stops": [
-            [
-              14,
-              10
-            ],
-            [
-              15,
-              10
-            ],
-            [
-              16,
-              11
-            ],
-            [
-              18,
-              12
-            ]
-          ]
-        },
+        "text-size": {"stops": [[14, 10], [15, 10], [16, 11], [18, 12]]},
         "text-field": "{name}",
         "symbol-avoid-edges": false,
-        "symbol-spacing": {
-          "stops": [
-            [
-              6,
-              200
-            ],
-            [
-              16,
-              250
-            ]
-          ]
-        },
+        "symbol-spacing": {"stops": [[6, 200], [16, 250]]},
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
         "text-justify": "center",
-        "text-letter-spacing": {
-          "stops": [
-            [
-              13,
-              0
-            ],
-            [
-              16,
-              0.2
-            ]
-          ]
-        }
+        "text-letter-spacing": {"stops": [[13, 0], [16, 0.2]]}
       },
       "paint": {
         "text-color": "#383838",
@@ -5863,18 +2412,7 @@
       "maxzoom": 24,
       "layout": {
         "text-field": "{housenumber}",
-        "text-size": {
-          "stops": [
-            [
-              17,
-              9
-            ],
-            [
-              18,
-              11
-            ]
-          ]
-        },
+        "text-size": {"stops": [[17, 9], [18, 11]]},
         "text-font": [
           "Montserrat Regular",
           "Open Sans Regular",

--- a/mapboxgl/dark-matter.json
+++ b/mapboxgl/dark-matter.json
@@ -490,7 +490,7 @@
       "paint": {
         "line-width": {"stops": [[15, 3], [16, 4], [17, 8], [18, 12]]},
         "line-opacity": 1,
-        "line-color": "rgba(238, 238, 238, 1)"
+        "line-color": "rgba(22, 22, 22, 1)"
       }
     },
     {

--- a/mapboxgl/dark-matter.json
+++ b/mapboxgl/dark-matter.json
@@ -1,7 +1,7 @@
 {
   "version": 8,
   "name": "Dark Matter",
-  "metadata": {"maputnik:renderer": "mbgljs"},
+  "metadata": { "maputnik:renderer": "mbgljs" },
   "sources": {
     "carto": {
       "type": "vector",
@@ -14,8 +14,8 @@
     {
       "id": "background",
       "type": "background",
-      "layout": {"visibility": "visible"},
-      "paint": {"background-color": "#0e0e0e", "background-opacity": 1}
+      "layout": { "visibility": "visible" },
+      "paint": { "background-color": "#0e0e0e", "background-opacity": 1 }
     },
     {
       "id": "landcover",
@@ -48,7 +48,7 @@
       "source-layer": "park",
       "minzoom": 9,
       "filter": ["all", ["==", "class", "national_park"]],
-      "layout": {"visibility": "visible"},
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
           "stops": [
@@ -70,7 +70,7 @@
       "source-layer": "park",
       "minzoom": 0,
       "filter": ["all", ["==", "class", "nature_reserve"]],
-      "layout": {"visibility": "visible"},
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
           "stops": [
@@ -82,7 +82,12 @@
           ]
         },
         "fill-antialias": true,
-        "fill-opacity": {"stops": [[6, 0.7], [9, 0.9]]}
+        "fill-opacity": {
+          "stops": [
+            [6, 0.7],
+            [9, 0.9]
+          ]
+        }
       }
     },
     {
@@ -104,7 +109,12 @@
             [16, "rgba(0, 0, 0, 0.15)"]
           ]
         },
-        "fill-opacity": {"stops": [[6, 0.6], [9, 1]]}
+        "fill-opacity": {
+          "stops": [
+            [6, 0.6],
+            [9, 1]
+          ]
+        }
       }
     },
     {
@@ -112,11 +122,7 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "landuse",
-      "filter": [
-        "any",
-        ["==", "class", "cemetery"],
-        ["==", "class", "stadium"]
-      ],
+      "filter": ["any", ["==", "class", "cemetery"], ["==", "class", "stadium"]],
       "paint": {
         "fill-color": {
           "stops": [
@@ -136,7 +142,14 @@
       "source-layer": "waterway",
       "paint": {
         "line-color": "rgba(63, 90, 109, 1)",
-        "line-width": {"stops": [[8, 0.5], [9, 1], [15, 2], [16, 3]]}
+        "line-width": {
+          "stops": [
+            [8, 0.5],
+            [9, 1],
+            [15, 2],
+            [16, 3]
+          ]
+        }
       }
     },
     {
@@ -148,9 +161,25 @@
       "maxzoom": 24,
       "filter": ["all", ["==", "admin_level", 6], ["==", "maritime", 0]],
       "paint": {
-        "line-color": {"stops": [[4, "#222"], [5, "#222"], [6, "#2C353C"]]},
-        "line-width": {"stops": [[4, 0.5], [7, 1]]},
-        "line-dasharray": {"stops": [[6, [1]], [7, [2, 2]]]}
+        "line-color": {
+          "stops": [
+            [4, "#222"],
+            [5, "#222"],
+            [6, "#2C353C"]
+          ]
+        },
+        "line-width": {
+          "stops": [
+            [4, 0.5],
+            [7, 1]
+          ]
+        },
+        "line-dasharray": {
+          "stops": [
+            [6, [1]],
+            [7, [2, 2]]
+          ]
+        }
       }
     },
     {
@@ -168,8 +197,20 @@
             [6, "rgba(103, 103, 114, 1)"]
           ]
         },
-        "line-width": {"stops": [[4, 0.5], [7, 1], [8, 1], [9, 1.2]]},
-        "line-dasharray": {"stops": [[6, [1, 2, 3]], [7, [1, 2, 3]]]}
+        "line-width": {
+          "stops": [
+            [4, 0.5],
+            [7, 1],
+            [8, 1],
+            [9, 1.2]
+          ]
+        },
+        "line-dasharray": {
+          "stops": [
+            [6, [1, 2, 3]],
+            [7, [1, 2, 3]]
+          ]
+        }
       }
     },
     {
@@ -180,7 +221,7 @@
       "minzoom": 0,
       "maxzoom": 24,
       "filter": ["all", ["==", "$type", "Polygon"]],
-      "layout": {"visibility": "visible"},
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": "#2C353C",
         "fill-antialias": true,
@@ -195,14 +236,19 @@
       "source-layer": "water",
       "minzoom": 0,
       "filter": ["all", ["==", "$type", "Polygon"]],
-      "layout": {"visibility": "visible"},
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": "transparent",
         "fill-antialias": true,
         "fill-translate-anchor": "map",
         "fill-opacity": 1,
         "fill-translate": {
-          "stops": [[0, [0, 2]], [6, [0, 1]], [14, [0, 1]], [17, [0, 2]]]
+          "stops": [
+            [0, [0, 2]],
+            [6, [0, 1]],
+            [14, [0, 1]],
+            [17, [0, 2]]
+          ]
         }
       }
     },
@@ -213,9 +259,17 @@
       "source-layer": "aeroway",
       "minzoom": 12,
       "filter": ["all", ["==", "class", "runway"]],
-      "layout": {"line-cap": "square"},
+      "layout": { "line-cap": "square" },
       "paint": {
-        "line-width": {"stops": [[11, 1], [13, 4], [14, 6], [15, 8], [16, 10]]},
+        "line-width": {
+          "stops": [
+            [11, 1],
+            [13, 4],
+            [14, 6],
+            [15, 8],
+            [16, 10]
+          ]
+        },
         "line-color": "#111"
       }
     },
@@ -228,7 +282,14 @@
       "filter": ["all", ["==", "class", "taxiway"]],
       "paint": {
         "line-color": "#111",
-        "line-width": {"stops": [[13, 0.5], [14, 1], [15, 2], [16, 4]]}
+        "line-width": {
+          "stops": [
+            [13, 0.5],
+            [14, 1],
+            [15, 2],
+            [16, 4]
+          ]
+        }
       }
     },
     {
@@ -249,12 +310,21 @@
         "symbol-placement": "line",
         "symbol-spacing": 300,
         "symbol-avoid-edges": false,
-        "text-size": {"stops": [[9, 8], [10, 9]]},
+        "text-size": {
+          "stops": [
+            [9, 8],
+            [10, 9]
+          ]
+        },
         "text-padding": 2,
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
         "text-offset": {
-          "stops": [[6, [0, -0.2]], [11, [0, -0.4]], [12, [0, -0.6]]]
+          "stops": [
+            [6, [0, -0.2]],
+            [11, [0, -0.4]],
+            [12, [0, -0.6]]
+          ]
         },
         "text-letter-spacing": 0,
         "text-keep-upright": true
@@ -272,14 +342,17 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "service"],
-        ["==", "brunnel", "tunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 1], [16, 3], [17, 6], [18, 8]]},
+        "line-width": {
+          "stops": [
+            [15, 1],
+            [16, 3],
+            [17, 6],
+            [18, 8]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#1a1a1a"
       }
@@ -292,7 +365,7 @@
       "minzoom": 13,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
-      "layout": {"line-cap": "butt", "line-join": "miter"},
+      "layout": { "line-cap": "butt", "line-join": "miter" },
       "paint": {
         "line-width": {
           "stops": [
@@ -316,12 +389,8 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["in", "class", "secondary", "tertiary"],
-        ["==", "brunnel", "tunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -346,13 +415,8 @@
       "source-layer": "transportation",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "primary"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "tunnel"]
-      ],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -368,7 +432,12 @@
             [18, 18]
           ]
         },
-        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
+        "line-opacity": {
+          "stops": [
+            [5, 0.5],
+            [7, 1]
+          ]
+        },
         "line-color": "#1a1a1a"
       }
     },
@@ -379,12 +448,7 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "trunk"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "tunnel"]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -405,7 +469,12 @@
             [18, 18]
           ]
         },
-        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
+        "line-opacity": {
+          "stops": [
+            [5, 0.5],
+            [7, 1]
+          ]
+        },
         "line-color": "#232323"
       }
     },
@@ -422,7 +491,7 @@
         ["!=", "ramp", 1],
         ["==", "brunnel", "tunnel"]
       ],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -439,7 +508,12 @@
             [18, 22]
           ]
         },
-        "line-opacity": {"stops": [[6, 0.5], [7, 1]]},
+        "line-opacity": {
+          "stops": [
+            [6, 0.5],
+            [7, 1]
+          ]
+        },
         "line-color": "#232323"
       }
     },
@@ -451,12 +525,23 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "tunnel"]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 0.5], [16, 1], [18, 3]]},
+        "line-width": {
+          "stops": [
+            [15, 0.5],
+            [16, 1],
+            [18, 3]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#262626",
-        "line-dasharray": {"stops": [[15, [2, 2]], [18, [3, 3]]]}
+        "line-dasharray": {
+          "stops": [
+            [15, [2, 2]],
+            [18, [3, 3]]
+          ]
+        }
       }
     },
     {
@@ -466,14 +551,17 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "service"],
-        ["==", "brunnel", "tunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 2], [16, 2], [17, 4], [18, 6]]},
+        "line-width": {
+          "stops": [
+            [15, 2],
+            [16, 2],
+            [17, 4],
+            [18, 6]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#161616"
       }
@@ -486,9 +574,16 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 3], [16, 4], [17, 8], [18, 12]]},
+        "line-width": {
+          "stops": [
+            [15, 3],
+            [16, 4],
+            [17, 8],
+            [18, 12]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "rgba(22, 22, 22, 1)"
       }
@@ -500,12 +595,8 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["in", "class", "secondary", "tertiary"],
-        ["==", "brunnel", "tunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -529,13 +620,8 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "primary"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "tunnel"]
-      ],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -559,12 +645,7 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "trunk"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "tunnel"]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
@@ -599,7 +680,7 @@
         ["!=", "ramp", 1],
         ["==", "brunnel", "tunnel"]
       ],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -624,12 +705,18 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
-      "layout": {"visibility": "visible", "line-join": "round"},
+      "layout": { "visibility": "visible", "line-join": "round" },
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
           "base": 1.3,
-          "stops": [[13, 0.5], [14, 1], [15, 1], [16, 3], [21, 7]]
+          "stops": [
+            [13, 0.5],
+            [14, 1],
+            [15, 1],
+            [16, 3],
+            [21, 7]
+          ]
         },
         "line-opacity": 0.5
       }
@@ -641,11 +728,23 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
-      "layout": {"visibility": "visible", "line-join": "round"},
+      "layout": { "visibility": "visible", "line-join": "round" },
       "paint": {
         "line-color": "#111",
-        "line-width": {"base": 1.3, "stops": [[15, 0.5], [16, 1], [20, 5]]},
-        "line-dasharray": {"stops": [[15, [5, 5]], [16, [6, 6]]]},
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [15, 0.5],
+            [16, 1],
+            [20, 5]
+          ]
+        },
+        "line-dasharray": {
+          "stops": [
+            [15, [5, 5]],
+            [16, [6, 6]]
+          ]
+        },
         "line-opacity": 0.5
       }
     },
@@ -657,9 +756,16 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 1], [16, 3], [17, 6], [18, 8]]},
+        "line-width": {
+          "stops": [
+            [15, 1],
+            [16, 3],
+            [17, 6],
+            [18, 8]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#1c1c1c"
       }
@@ -672,7 +778,7 @@
       "minzoom": 13,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -703,12 +809,24 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
-          "stops": [[12, 2], [13, 3], [14, 4], [15, 5], [16, 8], [17, 10]]
+          "stops": [
+            [12, 2],
+            [13, 3],
+            [14, 4],
+            [15, 5],
+            [16, 8],
+            [17, 10]
+          ]
         },
-        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
+        "line-opacity": {
+          "stops": [
+            [5, 0.5],
+            [7, 1]
+          ]
+        },
         "line-color": "#232323"
       }
     },
@@ -720,13 +838,25 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
-          "stops": [[12, 2], [13, 3], [14, 4], [15, 5], [16, 8], [17, 10]]
+          "stops": [
+            [12, 2],
+            [13, 3],
+            [14, 4],
+            [15, 5],
+            [16, 8],
+            [17, 10]
+          ]
         },
         "line-opacity": 1,
-        "line-color": {"stops": [[12, "#1a1a1a"], [14, "#232323"]]}
+        "line-color": {
+          "stops": [
+            [12, "#1a1a1a"],
+            [14, "#232323"]
+          ]
+        }
       }
     },
     {
@@ -737,13 +867,25 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
-          "stops": [[12, 2], [13, 3], [14, 4], [15, 5], [16, 8], [17, 10]]
+          "stops": [
+            [12, 2],
+            [13, 3],
+            [14, 4],
+            [15, 5],
+            [16, 8],
+            [17, 10]
+          ]
         },
         "line-opacity": 1,
-        "line-color": {"stops": [[12, "#1a1a1a"], [14, "#232323"]]}
+        "line-color": {
+          "stops": [
+            [12, "#1a1a1a"],
+            [14, "#232323"]
+          ]
+        }
       }
     },
     {
@@ -753,12 +895,8 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["in", "class", "secondary", "tertiary"],
-        ["!has", "brunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -789,13 +927,8 @@
       "source-layer": "transportation",
       "minzoom": 7,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "primary"],
-        ["!=", "ramp", 1],
-        ["!has", "brunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -811,8 +944,18 @@
             [18, 18]
           ]
         },
-        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
-        "line-color": {"stops": [[7, "#1a1a1a"], [12, "#232323"]]}
+        "line-opacity": {
+          "stops": [
+            [5, 0.5],
+            [7, 1]
+          ]
+        },
+        "line-color": {
+          "stops": [
+            [7, "#1a1a1a"],
+            [12, "#232323"]
+          ]
+        }
       }
     },
     {
@@ -822,13 +965,8 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "trunk"],
-        ["!=", "ramp", 1],
-        ["!has", "brunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -844,8 +982,18 @@
             [18, 18]
           ]
         },
-        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
-        "line-color": {"stops": [[5, "#1a1a1a"], [12, "#232323"]]}
+        "line-opacity": {
+          "stops": [
+            [5, 0.5],
+            [7, 1]
+          ]
+        },
+        "line-color": {
+          "stops": [
+            [5, "#1a1a1a"],
+            [12, "#232323"]
+          ]
+        }
       }
     },
     {
@@ -855,13 +1003,8 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["!has", "brunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -878,8 +1021,18 @@
             [18, 22]
           ]
         },
-        "line-opacity": {"stops": [[6, 0.5], [7, 1]]},
-        "line-color": {"stops": [[5, "#1a1a1a"], [12, "#232323"]]}
+        "line-opacity": {
+          "stops": [
+            [6, 0.5],
+            [7, 1]
+          ]
+        },
+        "line-color": {
+          "stops": [
+            [5, "#1a1a1a"],
+            [12, "#232323"]
+          ]
+        }
       }
     },
     {
@@ -890,12 +1043,23 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["in", "class", "path", "track"], ["!has", "brunnel"]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 0.5], [16, 1], [18, 3]]},
+        "line-width": {
+          "stops": [
+            [15, 0.5],
+            [16, 1],
+            [18, 3]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#262626",
-        "line-dasharray": {"stops": [[15, [2, 2]], [18, [3, 3]]]}
+        "line-dasharray": {
+          "stops": [
+            [15, [2, 2]],
+            [18, [3, 3]]
+          ]
+        }
       }
     },
     {
@@ -906,9 +1070,16 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 2], [16, 2], [17, 4], [18, 6]]},
+        "line-width": {
+          "stops": [
+            [15, 2],
+            [16, 2],
+            [17, 4],
+            [18, 6]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#0b0b0b"
       }
@@ -921,9 +1092,16 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 3], [16, 4], [17, 8], [18, 12]]},
+        "line-width": {
+          "stops": [
+            [15, 3],
+            [16, 4],
+            [17, 8],
+            [18, 12]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "rgba(65, 71, 88, 1)"
       }
@@ -936,10 +1114,17 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
-          "stops": [[12, 1], [13, 1.5], [14, 2], [15, 3], [16, 6], [17, 8]]
+          "stops": [
+            [12, 1],
+            [13, 1.5],
+            [14, 2],
+            [15, 3],
+            [16, 6],
+            [17, 8]
+          ]
         },
         "line-opacity": 1,
         "line-color": "#0b0b0b"
@@ -953,10 +1138,17 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
-      "layout": {"line-cap": "square", "line-join": "round"},
+      "layout": { "line-cap": "square", "line-join": "round" },
       "paint": {
         "line-width": {
-          "stops": [[12, 1], [13, 1.5], [14, 2], [15, 3], [16, 6], [17, 8]]
+          "stops": [
+            [12, 1],
+            [13, 1.5],
+            [14, 2],
+            [15, 3],
+            [16, 6],
+            [17, 8]
+          ]
         },
         "line-opacity": 1,
         "line-color": "#0b0b0b"
@@ -970,10 +1162,17 @@
       "minzoom": 12,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
-          "stops": [[12, 1], [13, 1.5], [14, 2], [15, 3], [16, 6], [17, 8]]
+          "stops": [
+            [12, 1],
+            [13, 1.5],
+            [14, 2],
+            [15, 3],
+            [16, 6],
+            [17, 8]
+          ]
         },
         "line-opacity": 1,
         "line-color": "rgba(65, 71, 88, 1)"
@@ -986,12 +1185,8 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["in", "class", "secondary", "tertiary"],
-        ["!has", "brunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1015,13 +1210,8 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "primary"],
-        ["!=", "ramp", 1],
-        ["!has", "brunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1045,13 +1235,8 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "trunk"],
-        ["!=", "ramp", 1],
-        ["!has", "brunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1075,13 +1260,8 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["!has", "brunnel"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1106,12 +1286,18 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
-      "layout": {"visibility": "visible", "line-join": "round"},
+      "layout": { "visibility": "visible", "line-join": "round" },
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
           "base": 1.3,
-          "stops": [[13, 0.5], [14, 1], [15, 1], [16, 3], [21, 7]]
+          "stops": [
+            [13, 0.5],
+            [14, 1],
+            [15, 1],
+            [16, 3],
+            [21, 7]
+          ]
         }
       }
     },
@@ -1122,11 +1308,23 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
-      "layout": {"visibility": "visible", "line-join": "round"},
+      "layout": { "visibility": "visible", "line-join": "round" },
       "paint": {
         "line-color": "#111",
-        "line-width": {"base": 1.3, "stops": [[15, 0.5], [16, 1], [20, 5]]},
-        "line-dasharray": {"stops": [[15, [5, 5]], [16, [6, 6]]]}
+        "line-width": {
+          "base": 1.3,
+          "stops": [
+            [15, 0.5],
+            [16, 1],
+            [20, 5]
+          ]
+        },
+        "line-dasharray": {
+          "stops": [
+            [15, [5, 5]],
+            [16, [6, 6]]
+          ]
+        }
       }
     },
     {
@@ -1136,14 +1334,17 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "service"],
-        ["==", "brunnel", "bridge"]
-      ],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 1], [16, 3], [17, 6], [18, 8]]},
+        "line-width": {
+          "stops": [
+            [15, 1],
+            [16, 3],
+            [17, 6],
+            [18, 8]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#1c1c1c"
       }
@@ -1156,7 +1357,7 @@
       "minzoom": 13,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
-      "layout": {"line-cap": "butt", "line-join": "miter"},
+      "layout": { "line-cap": "butt", "line-join": "miter" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1171,7 +1372,11 @@
         },
         "line-opacity": 1,
         "line-color": {
-          "stops": [[13, "#161616"], [15.7, "#161616"], [16, "#1c1c1c"]]
+          "stops": [
+            [13, "#161616"],
+            [15.7, "#161616"],
+            [16, "#1c1c1c"]
+          ]
         }
       }
     },
@@ -1182,12 +1387,8 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["in", "class", "secondary", "tertiary"],
-        ["==", "brunnel", "bridge"]
-      ],
-      "layout": {"line-cap": "butt", "line-join": "miter"},
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
+      "layout": { "line-cap": "butt", "line-join": "miter" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1203,7 +1404,11 @@
         },
         "line-opacity": 1,
         "line-color": {
-          "stops": [[11, "#1a1a1a"], [12.99, "#1a1a1a"], [13, "#232323"]]
+          "stops": [
+            [11, "#1a1a1a"],
+            [12.99, "#1a1a1a"],
+            [13, "#232323"]
+          ]
         }
       }
     },
@@ -1214,13 +1419,8 @@
       "source-layer": "transportation",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "primary"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "bridge"]
-      ],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1236,8 +1436,18 @@
             [18, 18]
           ]
         },
-        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
-        "line-color": {"stops": [[8, "#1a1a1a"], [12, "#232323"]]}
+        "line-opacity": {
+          "stops": [
+            [5, 0.5],
+            [7, 1]
+          ]
+        },
+        "line-color": {
+          "stops": [
+            [8, "#1a1a1a"],
+            [12, "#232323"]
+          ]
+        }
       }
     },
     {
@@ -1247,12 +1457,7 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "trunk"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "bridge"]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -1273,8 +1478,18 @@
             [18, 18]
           ]
         },
-        "line-opacity": {"stops": [[5, 0.5], [7, 1]]},
-        "line-color": {"stops": [[5, "#1a1a1a"], [12, "#232323"]]}
+        "line-opacity": {
+          "stops": [
+            [5, 0.5],
+            [7, 1]
+          ]
+        },
+        "line-color": {
+          "stops": [
+            [5, "#1a1a1a"],
+            [12, "#232323"]
+          ]
+        }
       }
     },
     {
@@ -1290,7 +1505,7 @@
         ["!=", "ramp", 1],
         ["==", "brunnel", "bridge"]
       ],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1307,8 +1522,18 @@
             [18, 22]
           ]
         },
-        "line-opacity": {"stops": [[6, 0.5], [7, 1]]},
-        "line-color": {"stops": [[5, "#1a1a1a"], [10, "#232323"]]}
+        "line-opacity": {
+          "stops": [
+            [6, 0.5],
+            [7, 1]
+          ]
+        },
+        "line-color": {
+          "stops": [
+            [5, "#1a1a1a"],
+            [10, "#232323"]
+          ]
+        }
       }
     },
     {
@@ -1319,12 +1544,23 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "bridge"]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 0.5], [16, 1], [18, 3]]},
+        "line-width": {
+          "stops": [
+            [15, 0.5],
+            [16, 1],
+            [18, 3]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#262626",
-        "line-dasharray": {"stops": [[15, [2, 2]], [18, [3, 3]]]}
+        "line-dasharray": {
+          "stops": [
+            [15, [2, 2]],
+            [18, [3, 3]]
+          ]
+        }
       }
     },
     {
@@ -1334,14 +1570,17 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "service"],
-        ["==", "brunnel", "bridge"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 2], [16, 2], [17, 4], [18, 6]]},
+        "line-width": {
+          "stops": [
+            [15, 2],
+            [16, 2],
+            [17, 4],
+            [18, 6]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#0b0b0b"
       }
@@ -1354,9 +1593,16 @@
       "minzoom": 15,
       "maxzoom": 24,
       "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
-        "line-width": {"stops": [[15, 3], [16, 4], [17, 8], [18, 12]]},
+        "line-width": {
+          "stops": [
+            [15, 3],
+            [16, 4],
+            [17, 8],
+            [18, 12]
+          ]
+        },
         "line-opacity": 1,
         "line-color": "#0b0b0b"
       }
@@ -1368,12 +1614,8 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["in", "class", "secondary", "tertiary"],
-        ["==", "brunnel", "bridge"]
-      ],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1397,13 +1639,8 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "primary"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "bridge"]
-      ],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1427,12 +1664,7 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": [
-        "all",
-        ["==", "class", "trunk"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "bridge"]
-      ],
+      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -1467,7 +1699,7 @@
         ["!=", "ramp", 1],
         ["==", "brunnel", "bridge"]
       ],
-      "layout": {"line-cap": "butt", "line-join": "round"},
+      "layout": { "line-cap": "butt", "line-join": "round" },
       "paint": {
         "line-width": {
           "stops": [
@@ -1490,11 +1722,14 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": {"visibility": "visible"},
+      "layout": { "visibility": "visible" },
       "paint": {
         "fill-color": {
           "base": 1,
-          "stops": [[15.5, "transparent"], [16, "transparent"]]
+          "stops": [
+            [15.5, "transparent"],
+            [16, "transparent"]
+          ]
         },
         "fill-antialias": true
       }
@@ -1504,12 +1739,24 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": {"visibility": "visible"},
+      "layout": { "visibility": "visible" },
       "paint": {
-        "fill-translate": {"base": 1, "stops": [[14, [0, 0]], [16, [-2, -2]]]},
+        "fill-translate": {
+          "base": 1,
+          "stops": [
+            [14, [0, 0]],
+            [16, [-2, -2]]
+          ]
+        },
         "fill-outline-color": "#0e0e0e",
         "fill-color": "rgba(57, 57, 57, 1)",
-        "fill-opacity": {"base": 1, "stops": [[13, 0], [16, 1]]}
+        "fill-opacity": {
+          "base": 1,
+          "stops": [
+            [13, 0],
+            [16, 1]
+          ]
+        }
       }
     },
     {
@@ -1520,7 +1767,7 @@
       "minzoom": 6,
       "maxzoom": 24,
       "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-color": "#2C353C",
         "line-opacity": 0.5,
@@ -1535,7 +1782,7 @@
       "source-layer": "boundary",
       "minzoom": 0,
       "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
-      "layout": {"line-cap": "round", "line-join": "round"},
+      "layout": { "line-cap": "round", "line-join": "round" },
       "paint": {
         "line-color": {
           "stops": [
@@ -1545,7 +1792,12 @@
           ]
         },
         "line-opacity": 1,
-        "line-width": {"stops": [[3, 1], [6, 1.5]]},
+        "line-width": {
+          "stops": [
+            [3, 1],
+            [6, 1.5]
+          ]
+        },
         "line-offset": 0
       }
     },
@@ -1556,16 +1808,17 @@
       "source-layer": "water_name",
       "minzoom": 0,
       "maxzoom": 5,
-      "filter": [
-        "all",
-        ["has", "name"],
-        ["==", "$type", "Point"],
-        ["==", "class", "ocean"]
-      ],
+      "filter": ["all", ["has", "name"], ["==", "$type", "Point"], ["==", "class", "ocean"]],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "point",
-        "text-size": {"stops": [[0, 13], [2, 14], [4, 18]]},
+        "text-size": {
+          "stops": [
+            [0, 13],
+            [2, 14],
+            [4, 18]
+          ]
+        },
         "text-font": [
           "Montserrat Medium Italic",
           "Open Sans Italic",
@@ -1595,12 +1848,7 @@
       "source": "carto",
       "source-layer": "water_name",
       "minzoom": 5,
-      "filter": [
-        "all",
-        ["has", "name"],
-        ["==", "$type", "Point"],
-        ["==", "class", "sea"]
-      ],
+      "filter": ["all", ["has", "name"], ["==", "$type", "Point"], ["==", "class", "sea"]],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "point",
@@ -1634,17 +1882,23 @@
       "source": "carto",
       "source-layer": "water_name",
       "minzoom": 4,
-      "filter": [
-        "all",
-        ["has", "name"],
-        ["==", "$type", "Point"],
-        ["==", "class", "lake"]
-      ],
+      "filter": ["all", ["has", "name"], ["==", "$type", "Point"], ["==", "class", "lake"]],
       "layout": {
-        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
+        "text-field": {
+          "stops": [
+            [8, "{name_en}"],
+            [13, "{name}"]
+          ]
+        },
         "symbol-placement": "point",
         "text-size": {
-          "stops": [[13, 9], [14, 10], [15, 11], [16, 12], [17, 13]]
+          "stops": [
+            [13, 9],
+            [14, 10],
+            [15, 11],
+            [16, 12],
+            [17, 13]
+          ]
         },
         "text-font": [
           "Montserrat Regular Italic",
@@ -1674,10 +1928,21 @@
       "source-layer": "water_name",
       "filter": ["all", ["has", "name"], ["==", "$type", "LineString"]],
       "layout": {
-        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
+        "text-field": {
+          "stops": [
+            [8, "{name_en}"],
+            [13, "{name}"]
+          ]
+        },
         "symbol-placement": "line",
         "text-size": {
-          "stops": [[13, 9], [14, 10], [15, 11], [16, 12], [17, 13]]
+          "stops": [
+            [13, 9],
+            [14, 10],
+            [15, 11],
+            [16, 12],
+            [17, 13]
+          ]
         },
         "text-font": [
           "Montserrat Regular Italic",
@@ -1705,13 +1970,14 @@
       "source-layer": "place",
       "minzoom": 12,
       "maxzoom": 16,
-      "filter": [
-        "any",
-        ["==", "class", "neighbourhood"],
-        ["==", "class", "hamlet"]
-      ],
+      "filter": ["any", ["==", "class", "neighbourhood"], ["==", "class", "hamlet"]],
       "layout": {
-        "text-field": {"stops": [[8, "{name_en}"], [14, "{name}"]]},
+        "text-field": {
+          "stops": [
+            [8, "{name_en}"],
+            [14, "{name}"]
+          ]
+        },
         "text-font": [
           "Montserrat Regular",
           "Open Sans Regular",
@@ -1719,7 +1985,13 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[13, 8], [14, 10], [16, 11]]},
+        "text-size": {
+          "stops": [
+            [13, 8],
+            [14, 10],
+            [16, 11]
+          ]
+        },
         "icon-image": "",
         "icon-offset": [16, 0],
         "text-anchor": "center",
@@ -1727,7 +1999,12 @@
         "text-max-width": 10,
         "text-keep-upright": true,
         "text-offset": [0.2, 0.2],
-        "text-transform": {"stops": [[12, "none"], [14, "uppercase"]]}
+        "text-transform": {
+          "stops": [
+            [12, "none"],
+            [14, "uppercase"]
+          ]
+        }
       },
       "paint": {
         "text-color": "rgba(182, 180, 180, 1)",
@@ -1746,7 +2023,12 @@
       "maxzoom": 16,
       "filter": ["all", ["==", "class", "suburb"]],
       "layout": {
-        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
+        "text-field": {
+          "stops": [
+            [8, "{name_en}"],
+            [13, "{name}"]
+          ]
+        },
         "text-font": [
           "Montserrat Regular",
           "Open Sans Regular",
@@ -1755,7 +2037,13 @@
           "NanumBarunGothic Regular"
         ],
         "text-size": {
-          "stops": [[12, 9], [13, 10], [14, 11], [15, 12], [16, 13]]
+          "stops": [
+            [12, 9],
+            [13, 10],
+            [14, 11],
+            [15, 12],
+            [16, 13]
+          ]
         },
         "icon-image": "",
         "icon-offset": [16, 0],
@@ -1764,7 +2052,12 @@
         "text-max-width": 10,
         "text-keep-upright": true,
         "text-offset": [0.2, 0.2],
-        "text-transform": {"stops": [[8, "none"], [12, "uppercase"]]}
+        "text-transform": {
+          "stops": [
+            [8, "none"],
+            [12, "uppercase"]
+          ]
+        }
       },
       "paint": {
         "text-color": "#666",
@@ -1783,7 +2076,12 @@
       "maxzoom": 16,
       "filter": ["all", ["==", "class", "village"]],
       "layout": {
-        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
+        "text-field": {
+          "stops": [
+            [8, "{name_en}"],
+            [13, "{name}"]
+          ]
+        },
         "text-font": [
           "Montserrat Medium",
           "Open Sans Bold",
@@ -1792,7 +2090,13 @@
           "NanumBarunGothic Regular"
         ],
         "text-size": {
-          "stops": [[10, 9], [12, 10], [13, 11], [14, 12], [16, 13]]
+          "stops": [
+            [10, 9],
+            [12, 10],
+            [13, 11],
+            [14, 12],
+            [16, 13]
+          ]
         },
         "icon-image": "",
         "icon-offset": [16, 0],
@@ -1820,7 +2124,12 @@
       "maxzoom": 14,
       "filter": ["all", ["==", "class", "town"]],
       "layout": {
-        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
+        "text-field": {
+          "stops": [
+            [8, "{name_en}"],
+            [13, "{name}"]
+          ]
+        },
         "text-font": [
           "Montserrat Medium",
           "Open Sans Bold",
@@ -1829,7 +2138,13 @@
           "NanumBarunGothic Regular"
         ],
         "text-size": {
-          "stops": [[8, 10], [9, 10], [10, 11], [13, 14], [14, 15]]
+          "stops": [
+            [8, 10],
+            [9, 10],
+            [10, 11],
+            [13, 14],
+            [14, 15]
+          ]
         },
         "icon-image": "",
         "icon-offset": [16, 0],
@@ -1855,12 +2170,7 @@
       "source-layer": "place",
       "minzoom": 3,
       "maxzoom": 10,
-      "filter": [
-        "all",
-        ["==", "class", "country"],
-        [">=", "rank", 3],
-        ["has", "iso_a2"]
-      ],
+      "filter": ["all", ["==", "class", "country"], [">=", "rank", 3], ["has", "iso_a2"]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -1870,7 +2180,15 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[3, 10], [5, 11], [6, 12], [7, 13], [8, 14]]},
+        "text-size": {
+          "stops": [
+            [3, 10],
+            [5, 11],
+            [6, 12],
+            [7, 13],
+            [8, 14]
+          ]
+        },
         "text-transform": "uppercase"
       },
       "paint": {
@@ -1902,9 +2220,23 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[3, 11], [4, 12], [5, 13], [6, 14]]},
+        "text-size": {
+          "stops": [
+            [3, 11],
+            [4, 12],
+            [5, 13],
+            [6, 14]
+          ]
+        },
         "text-transform": "uppercase",
-        "text-max-width": {"stops": [[2, 6], [3, 6], [4, 9], [5, 12]]}
+        "text-max-width": {
+          "stops": [
+            [2, 6],
+            [3, 6],
+            [4, 9],
+            [5, 12]
+          ]
+        }
       },
       "paint": {
         "text-color": {
@@ -1935,7 +2267,12 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[5, 12], [7, 14]]},
+        "text-size": {
+          "stops": [
+            [5, 12],
+            [7, 14]
+          ]
+        },
         "text-transform": "uppercase",
         "text-max-width": 9
       },
@@ -1984,7 +2321,12 @@
       "maxzoom": 15,
       "filter": ["all", ["==", "class", "city"], [">=", "rank", 6]],
       "layout": {
-        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
+        "text-field": {
+          "stops": [
+            [8, "{name_en}"],
+            [13, "{name}"]
+          ]
+        },
         "text-font": [
           "Montserrat Medium",
           "Open Sans Bold",
@@ -1993,7 +2335,13 @@
           "NanumBarunGothic Regular"
         ],
         "text-size": {
-          "stops": [[8, 12], [9, 13], [10, 14], [13, 17], [14, 20]]
+          "stops": [
+            [8, 12],
+            [9, 13],
+            [10, 14],
+            [13, 17],
+            [14, 20]
+          ]
         },
         "icon-image": "",
         "icon-offset": [16, 0],
@@ -2019,14 +2367,14 @@
       "source-layer": "place",
       "minzoom": 8,
       "maxzoom": 15,
-      "filter": [
-        "all",
-        ["==", "class", "city"],
-        [">=", "rank", 0],
-        ["<=", "rank", 5]
-      ],
+      "filter": ["all", ["==", "class", "city"], [">=", "rank", 0], ["<=", "rank", 5]],
       "layout": {
-        "text-field": {"stops": [[8, "{name_en}"], [13, "{name}"]]},
+        "text-field": {
+          "stops": [
+            [8, "{name_en}"],
+            [13, "{name}"]
+          ]
+        },
         "text-font": [
           "Montserrat Medium",
           "Open Sans Bold",
@@ -2034,7 +2382,14 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[8, 14], [10, 16], [13, 19], [14, 22]]},
+        "text-size": {
+          "stops": [
+            [8, 14],
+            [10, 16],
+            [13, 19],
+            [14, 22]
+          ]
+        },
         "icon-image": "",
         "icon-offset": [16, 0],
         "text-anchor": "center",
@@ -2161,11 +2516,7 @@
       "source-layer": "place",
       "minzoom": 7,
       "maxzoom": 8,
-      "filter": [
-        "all",
-        ["!has", "capital"],
-        ["!in", "class", "country", "state"]
-      ],
+      "filter": ["all", ["!has", "capital"], ["!in", "class", "country", "state"]],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2233,11 +2584,7 @@
       "source": "carto",
       "source-layer": "poi",
       "minzoom": 15,
-      "filter": [
-        "all",
-        ["in", "class", "stadium", "cemetery", "attraction"],
-        ["<=", "rank", 3]
-      ],
+      "filter": ["all", ["in", "class", "stadium", "cemetery", "attraction"], ["<=", "rank", 3]],
       "layout": {
         "text-field": "{name}",
         "text-font": [
@@ -2247,7 +2594,13 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[15, 8], [17, 9], [18, 10]]},
+        "text-size": {
+          "stops": [
+            [15, 8],
+            [17, 9],
+            [18, 10]
+          ]
+        },
         "text-transform": "uppercase"
       },
       "paint": {
@@ -2272,7 +2625,13 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[15, 8], [17, 9], [18, 10]]},
+        "text-size": {
+          "stops": [
+            [15, 8],
+            [17, 9],
+            [18, 10]
+          ]
+        },
         "text-transform": "uppercase"
       },
       "paint": {
@@ -2327,7 +2686,13 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[15, 9], [16, 11], [18, 12]]},
+        "text-size": {
+          "stops": [
+            [15, 9],
+            [16, 11],
+            [18, 12]
+          ]
+        },
         "text-field": "{name}",
         "symbol-avoid-edges": false,
         "symbol-spacing": 200,
@@ -2357,14 +2722,31 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[14, 10], [15, 10], [16, 11], [18, 12]]},
+        "text-size": {
+          "stops": [
+            [14, 10],
+            [15, 10],
+            [16, 11],
+            [18, 12]
+          ]
+        },
         "text-field": "{name}",
         "symbol-avoid-edges": false,
-        "symbol-spacing": {"stops": [[6, 200], [16, 250]]},
+        "symbol-spacing": {
+          "stops": [
+            [6, 200],
+            [16, 250]
+          ]
+        },
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
         "text-justify": "center",
-        "text-letter-spacing": {"stops": [[14, 0], [16, 0.2]]}
+        "text-letter-spacing": {
+          "stops": [
+            [14, 0],
+            [16, 0.2]
+          ]
+        }
       },
       "paint": {
         "text-color": "rgba(189, 189, 189, 1)",
@@ -2388,14 +2770,31 @@
           "HanWangHeiLight Regular",
           "NanumBarunGothic Regular"
         ],
-        "text-size": {"stops": [[14, 10], [15, 10], [16, 11], [18, 12]]},
+        "text-size": {
+          "stops": [
+            [14, 10],
+            [15, 10],
+            [16, 11],
+            [18, 12]
+          ]
+        },
         "text-field": "{name}",
         "symbol-avoid-edges": false,
-        "symbol-spacing": {"stops": [[6, 200], [16, 250]]},
+        "symbol-spacing": {
+          "stops": [
+            [6, 200],
+            [16, 250]
+          ]
+        },
         "text-pitch-alignment": "auto",
         "text-rotation-alignment": "auto",
         "text-justify": "center",
-        "text-letter-spacing": {"stops": [[13, 0], [16, 0.2]]}
+        "text-letter-spacing": {
+          "stops": [
+            [13, 0],
+            [16, 0.2]
+          ]
+        }
       },
       "paint": {
         "text-color": "#383838",
@@ -2412,7 +2811,12 @@
       "maxzoom": 24,
       "layout": {
         "text-field": "{housenumber}",
-        "text-size": {"stops": [[17, 9], [18, 11]]},
+        "text-size": {
+          "stops": [
+            [17, 9],
+            [18, 11]
+          ]
+        },
         "text-font": [
           "Montserrat Regular",
           "Open Sans Regular",

--- a/mapboxgl/dark-matter.json
+++ b/mapboxgl/dark-matter.json
@@ -293,49 +293,6 @@
       }
     },
     {
-      "id": "waterway_label",
-      "type": "symbol",
-      "source": "carto",
-      "source-layer": "waterway",
-      "filter": ["all", ["has", "name"], ["==", "class", "river"]],
-      "layout": {
-        "text-field": "{name_en}",
-        "text-font": [
-          "Montserrat Regular Italic",
-          "Open Sans Italic",
-          "Noto Sans Regular",
-          "HanWangHeiLight Regular",
-          "NanumBarunGothic Regular"
-        ],
-        "symbol-placement": "line",
-        "symbol-spacing": 300,
-        "symbol-avoid-edges": false,
-        "text-size": {
-          "stops": [
-            [9, 8],
-            [10, 9]
-          ]
-        },
-        "text-padding": 2,
-        "text-pitch-alignment": "auto",
-        "text-rotation-alignment": "auto",
-        "text-offset": {
-          "stops": [
-            [6, [0, -0.2]],
-            [11, [0, -0.4]],
-            [12, [0, -0.6]]
-          ]
-        },
-        "text-letter-spacing": 0,
-        "text-keep-upright": true
-      },
-      "paint": {
-        "text-color": "rgba(164, 164, 164, 1)",
-        "text-halo-color": "#181818",
-        "text-halo-width": 1
-      }
-    },
-    {
       "id": "tunnel_service_case",
       "type": "line",
       "source": "carto",
@@ -1799,6 +1756,49 @@
           ]
         },
         "line-offset": 0
+      }
+    },
+    {
+      "id": "waterway_label",
+      "type": "symbol",
+      "source": "carto",
+      "source-layer": "waterway",
+      "filter": ["all", ["has", "name"], ["==", "class", "river"]],
+      "layout": {
+        "text-field": "{name_en}",
+        "text-font": [
+          "Montserrat Regular Italic",
+          "Open Sans Italic",
+          "Noto Sans Regular",
+          "HanWangHeiLight Regular",
+          "NanumBarunGothic Regular"
+        ],
+        "symbol-placement": "line",
+        "symbol-spacing": 300,
+        "symbol-avoid-edges": false,
+        "text-size": {
+          "stops": [
+            [9, 8],
+            [10, 9]
+          ]
+        },
+        "text-padding": 2,
+        "text-pitch-alignment": "auto",
+        "text-rotation-alignment": "auto",
+        "text-offset": {
+          "stops": [
+            [6, [0, -0.2]],
+            [11, [0, -0.4]],
+            [12, [0, -0.6]]
+          ]
+        },
+        "text-letter-spacing": 0,
+        "text-keep-upright": true
+      },
+      "paint": {
+        "text-color": "rgba(164, 164, 164, 1)",
+        "text-halo-color": "#181818",
+        "text-halo-width": 1
       }
     },
     {


### PR DESCRIPTION
Exactly same changes proposed at #25, but updating current dark-matter version (instead of creating a new variation, dark-matter-v2).

Once deployed, it will update vector map for all clients, without any specific action

[sc-192792]


CURRENT
![image](https://user-images.githubusercontent.com/458196/178605962-3a0d435d-a81f-4356-bcd2-0c8d48731070.png)

NEW
![image](https://user-images.githubusercontent.com/458196/178606333-0d21ccad-9995-4cba-9930-2a6e88ae07ad.png)


Closes #25 