### PR TITLE
Update dark-matter / dark-matter nolabels to have better legibility (2)

### DIFF
--- a/mapboxgl/dark-matter-nolabels.json
+++ b/mapboxgl/dark-matter-nolabels.json
@@ -1,11 +1,11 @@
 {
   "version": 8,
   "name": "Dark Matter without labels",
-  "metadata": { "maputnik:renderer": "mbgljs" },
+  "metadata": {},
   "sources": {
     "carto": {
       "type": "vector",
-      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json"
+      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json{api_key}"
     }
   },
   "sprite": "https://tiles.basemaps.cartocdn.com/gl/dark-matter-gl-style/sprite",
@@ -14,8 +14,13 @@
     {
       "id": "background",
       "type": "background",
-      "layout": { "visibility": "visible" },
-      "paint": { "background-color": "#0e0e0e", "background-opacity": 1 }
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "background-color": "#0e0e0e",
+        "background-opacity": 1
+      }
     },
     {
       "id": "landcover",
@@ -24,18 +29,45 @@
       "source-layer": "landcover",
       "filter": [
         "any",
-        ["==", "class", "wood"],
-        ["==", "class", "grass"],
-        ["==", "subclass", "recreation_ground"]
+        [
+          "==",
+          "class",
+          "wood"
+        ],
+        [
+          "==",
+          "class",
+          "grass"
+        ],
+        [
+          "==",
+          "subclass",
+          "recreation_ground"
+        ]
       ],
       "paint": {
         "fill-color": {
           "stops": [
-            [8, "#0e0e0e"],
-            [9, "#0e0e0e"],
-            [11, "#0e0e0e"],
-            [13, "#0e0e0e"],
-            [15, "#0e0e0e"]
+            [
+              8,
+              "#0e0e0e"
+            ],
+            [
+              9,
+              "#0e0e0e"
+            ],
+            [
+              11,
+              "#0e0e0e"
+            ],
+            [
+              13,
+              "#0e0e0e"
+            ],
+            [
+              15,
+              "#0e0e0e"
+            ]
           ]
         },
         "fill-opacity": 1
@@ -47,16 +79,40 @@
       "source": "carto",
       "source-layer": "park",
       "minzoom": 9,
-      "filter": ["all", ["==", "class", "national_park"]],
-      "layout": { "visibility": "visible" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "national_park"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": {
           "stops": [
-            [8, "#0e0e0e"],
-            [9, "#0e0e0e"],
-            [11, "#0e0e0e"],
-            [13, "#0e0e0e"],
-            [15, "#0e0e0e"]
+            [
+              8,
+              "#0e0e0e"
+            ],
+            [
+              9,
+              "#0e0e0e"
+            ],
+            [
+              11,
+              "#0e0e0e"
+            ],
+            [
+              13,
+              "#0e0e0e"
+            ],
+            [
+              15,
+              "#0e0e0e"
+            ]
           ]
         },
         "fill-opacity": 1,
@@ -69,23 +125,53 @@
       "source": "carto",
       "source-layer": "park",
       "minzoom": 0,
-      "filter": ["all", ["==", "class", "nature_reserve"]],
-      "layout": { "visibility": "visible" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "nature_reserve"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": {
           "stops": [
-            [8, "#0e0e0e"],
-            [9, "#0e0e0e"],
-            [11, "#0e0e0e"],
-            [13, "#0e0e0e"],
-            [15, "#0e0e0e"]
+            [
+              8,
+              "#0e0e0e"
+            ],
+            [
+              9,
+              "#0e0e0e"
+            ],
+            [
+              11,
+              "#0e0e0e"
+            ],
+            [
+              13,
+              "#0e0e0e"
+            ],
+            [
+              15,
+              "#0e0e0e"
+            ]
           ]
         },
         "fill-antialias": true,
         "fill-opacity": {
           "stops": [
-            [6, 0.7],
-            [9, 0.9]
+            [
+              6,
+              0.7
+            ],
+            [
+              9,
+              0.9
+            ]
           ]
         }
       }
@@ -96,23 +182,57 @@
       "source": "carto",
       "source-layer": "landuse",
       "minzoom": 6,
-      "filter": ["any", ["==", "class", "residential"]],
+      "filter": [
+        "any",
+        [
+          "==",
+          "class",
+          "residential"
+        ]
+      ],
       "paint": {
         "fill-color": {
           "stops": [
-            [5, "rgba(0, 0, 0, 0.5)"],
-            [8, "rgba(0, 0, 0, 0.45)"],
-            [9, "rgba(0, 0, 0, 0.4)"],
-            [11, "rgba(0, 0, 0, 0.35)"],
-            [13, "rgba(0, 0, 0, 0.3)"],
-            [15, "rgba(0, 0, 0, 0.25)"],
-            [16, "rgba(0, 0, 0, 0.15)"]
+            [
+              5,
+              "rgba(0, 0, 0, 0.5)"
+            ],
+            [
+              8,
+              "rgba(0, 0, 0, 0.45)"
+            ],
+            [
+              9,
+              "rgba(0, 0, 0, 0.4)"
+            ],
+            [
+              11,
+              "rgba(0, 0, 0, 0.35)"
+            ],
+            [
+              13,
+              "rgba(0, 0, 0, 0.3)"
+            ],
+            [
+              15,
+              "rgba(0, 0, 0, 0.25)"
+            ],
+            [
+              16,
+              "rgba(0, 0, 0, 0.15)"
+            ]
           ]
         },
         "fill-opacity": {
           "stops": [
-            [6, 0.6],
-            [9, 1]
+            [
+              6,
+              0.6
+            ],
+            [
+              9,
+              1
+            ]
           ]
         }
       }
@@ -122,15 +242,42 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "landuse",
-      "filter": ["any", ["==", "class", "cemetery"], ["==", "class", "stadium"]],
+      "filter": [
+        "any",
+        [
+          "==",
+          "class",
+          "cemetery"
+        ],
+        [
+          "==",
+          "class",
+          "stadium"
+        ]
+      ],
       "paint": {
         "fill-color": {
           "stops": [
-            [8, "#0e0e0e"],
-            [9, "#0e0e0e"],
-            [11, "#0e0e0e"],
-            [13, "#0e0e0e"],
-            [15, "#0e0e0e"]
+            [
+              8,
+              "#0e0e0e"
+            ],
+            [
+              9,
+              "#0e0e0e"
+            ],
+            [
+              11,
+              "#0e0e0e"
+            ],
+            [
+              13,
+              "#0e0e0e"
+            ],
+            [
+              15,
+              "#0e0e0e"
+            ]
           ]
         }
       }
@@ -141,13 +288,25 @@
       "source": "carto",
       "source-layer": "waterway",
       "paint": {
-        "line-color": "rgba(63, 90, 109, 1)",
+        "line-color": "#151515",
         "line-width": {
           "stops": [
-            [8, 0.5],
-            [9, 1],
-            [15, 2],
-            [16, 3]
+            [
+              8,
+              0.5
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              3
+            ]
           ]
         }
       }
@@ -159,25 +318,63 @@
       "source-layer": "boundary",
       "minzoom": 9,
       "maxzoom": 24,
-      "filter": ["all", ["==", "admin_level", 6], ["==", "maritime", 0]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          6
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ],
       "paint": {
         "line-color": {
           "stops": [
-            [4, "#222"],
-            [5, "#222"],
-            [6, "#2C353C"]
+            [
+              4,
+              "#222"
+            ],
+            [
+              5,
+              "#222"
+            ],
+            [
+              6,
+              "#292929"
+            ]
           ]
         },
         "line-width": {
           "stops": [
-            [4, 0.5],
-            [7, 1]
+            [
+              4,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [6, [1]],
-            [7, [2, 2]]
+            [
+              6,
+              [
+                1
+              ]
+            ],
+            [
+              7,
+              [
+                2,
+                2
+              ]
+            ]
           ]
         }
       }
@@ -188,27 +385,71 @@
       "source": "carto",
       "source-layer": "boundary",
       "minzoom": 4,
-      "filter": ["all", ["==", "admin_level", 4], ["==", "maritime", 0]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          4
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ],
       "paint": {
         "line-color": {
           "stops": [
-            [4, "rgba(103, 103, 114, 1)"],
-            [5, "rgba(103, 103, 114, 1)"],
-            [6, "rgba(103, 103, 114, 1)"]
+            [
+              4,
+              "#222"
+            ],
+            [
+              5,
+              "#222"
+            ],
+            [
+              6,
+              "#292929"
+            ]
           ]
         },
         "line-width": {
           "stops": [
-            [4, 0.5],
-            [7, 1],
-            [8, 1],
-            [9, 1.2]
+            [
+              4,
+              0.5
+            ],
+            [
+              7,
+              1
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1.2
+            ]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [6, [1, 2, 3]],
-            [7, [1, 2, 3]]
+            [
+              6,
+              [
+                1
+              ]
+            ],
+            [
+              7,
+              [
+                2,
+                2
+              ]
+            ]
           ]
         }
       }
@@ -220,10 +461,19 @@
       "source-layer": "water",
       "minzoom": 0,
       "maxzoom": 24,
-      "filter": ["all", ["==", "$type", "Polygon"]],
-      "layout": { "visibility": "visible" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
-        "fill-color": "#2C353C",
+        "fill-color": "#212121",
         "fill-antialias": true,
         "fill-translate-anchor": "map",
         "fill-opacity": 1
@@ -235,8 +485,17 @@
       "source": "carto",
       "source-layer": "water",
       "minzoom": 0,
-      "filter": ["all", ["==", "$type", "Polygon"]],
-      "layout": { "visibility": "visible" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": "transparent",
         "fill-antialias": true,
@@ -244,10 +503,34 @@
         "fill-opacity": 1,
         "fill-translate": {
           "stops": [
-            [0, [0, 2]],
-            [6, [0, 1]],
-            [14, [0, 1]],
-            [17, [0, 2]]
+            [
+              0,
+              [
+                0,
+                2
+              ]
+            ],
+            [
+              6,
+              [
+                0,
+                1
+              ]
+            ],
+            [
+              14,
+              [
+                0,
+                1
+              ]
+            ],
+            [
+              17,
+              [
+                0,
+                2
+              ]
+            ]
           ]
         }
       }
@@ -258,16 +541,40 @@
       "source": "carto",
       "source-layer": "aeroway",
       "minzoom": 12,
-      "filter": ["all", ["==", "class", "runway"]],
-      "layout": { "line-cap": "square" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "runway"
+        ]
+      ],
+      "layout": {
+        "line-cap": "square"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ]
           ]
         },
         "line-color": "#111"
@@ -279,15 +586,34 @@
       "source": "carto",
       "source-layer": "aeroway",
       "minzoom": 13,
-      "filter": ["all", ["==", "class", "taxiway"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "taxiway"
+        ]
+      ],
       "paint": {
         "line-color": "#111",
         "line-width": {
           "stops": [
-            [13, 0.5],
-            [14, 1],
-            [15, 2],
-            [16, 4]
+            [
+              13,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              4
+            ]
           ]
         }
       }
@@ -299,15 +625,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 1],
-            [16, 3],
-            [17, 6],
-            [18, 8]
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              17,
+              6
+            ],
+            [
+              18,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -321,18 +674,54 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "butt", "line-join": "miter" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 0.5],
-            [14, 2],
-            [15, 4],
-            [16, 6],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
@@ -346,19 +735,59 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 1],
-            [13, 2],
-            [14, 5],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
@@ -372,27 +801,83 @@
       "source-layer": "transportation",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": "#1a1a1a"
@@ -405,7 +890,24 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -414,22 +916,58 @@
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": "#232323"
@@ -444,31 +982,85 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "tunnel"]
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
       ],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [12, 4],
-            [13, 5],
-            [14, 7],
-            [15, 9],
-            [16, 11],
-            [17, 13],
-            [18, 22]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              12,
+              4
+            ],
+            [
+              13,
+              5
+            ],
+            [
+              14,
+              7
+            ],
+            [
+              15,
+              9
+            ],
+            [
+              16,
+              11
+            ],
+            [
+              17,
+              13
+            ],
+            [
+              18,
+              22
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [6, 0.5],
-            [7, 1]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": "#232323"
@@ -481,22 +1073,58 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "path"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [18, 3]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              3
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": "#262626",
         "line-dasharray": {
           "stops": [
-            [15, [2, 2]],
-            [18, [3, 3]]
+            [
+              15,
+              [
+                2,
+                2
+              ]
+            ],
+            [
+              18,
+              [
+                3,
+                3
+              ]
+            ]
           ]
         }
       }
@@ -508,15 +1136,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 2],
-            [16, 2],
-            [17, 4],
-            [18, 6]
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              17,
+              4
+            ],
+            [
+              18,
+              6
+            ]
           ]
         },
         "line-opacity": 1,
@@ -530,19 +1185,46 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 3],
-            [16, 4],
-            [17, 8],
-            [18, 12]
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              17,
+              8
+            ],
+            [
+              18,
+              12
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(22, 22, 22, 1)"
+        "line-color": "rgba(238, 238, 238, 1)"
       }
     },
     {
@@ -552,18 +1234,55 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 2],
-            [13, 2],
-            [14, 3],
-            [15, 4],
-            [16, 6],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              2
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              3
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
@@ -577,22 +1296,63 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#161616"
       }
     },
     {
@@ -602,7 +1362,24 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
@@ -611,13 +1388,34 @@
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
@@ -633,26 +1431,65 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "tunnel"]
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
       ],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [10, 1],
-            [12, 2],
-            [13, 3],
-            [14, 5],
-            [15, 7],
-            [16, 9],
-            [17, 11],
-            [18, 20]
+            [
+              10,
+              1
+            ],
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              7
+            ],
+            [
+              16,
+              9
+            ],
+            [
+              17,
+              11
+            ],
+            [
+              18,
+              20
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#161616"
       }
     },
     {
@@ -661,18 +1498,48 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
           "base": 1.3,
           "stops": [
-            [13, 0.5],
-            [14, 1],
-            [15, 1],
-            [16, 3],
-            [21, 7]
+            [
+              13,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              21,
+              7
+            ]
           ]
         },
         "line-opacity": 0.5
@@ -684,22 +1551,58 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 15,
-      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "#111",
         "line-width": {
           "base": 1.3,
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [20, 5]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              20,
+              5
+            ]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [15, [5, 5]],
-            [16, [6, 6]]
+            [
+              15,
+              [
+                5,
+                5
+              ]
+            ],
+            [
+              16,
+              [
+                6,
+                6
+              ]
+            ]
           ]
         },
         "line-opacity": 0.5
@@ -712,15 +1615,41 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 1],
-            [16, 3],
-            [17, 6],
-            [18, 8]
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              17,
+              6
+            ],
+            [
+              18,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -734,26 +1663,71 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 0.5],
-            [14, 2],
-            [15, 3],
-            [16, 4.3],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4.3
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
+        "line-opacity": 1,
         "line-color": {
           "stops": [
-            [13, "rgba(65, 71, 88, 1)"],
-            [15.7, "rgba(65, 71, 88, 1)"],
-            [16, "rgba(65, 71, 88, 1)"]
+            [
+              13,
+              "#161616"
+            ],
+            [
+              15.7,
+              "#161616"
+            ],
+            [
+              16,
+              "#1c1c1c"
+            ]
           ]
         }
       }
@@ -765,23 +1739,62 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 2],
-            [13, 3],
-            [14, 4],
-            [15, 5],
-            [16, 8],
-            [17, 10]
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": "#232323"
@@ -794,24 +1807,63 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 2],
-            [13, 3],
-            [14, 4],
-            [15, 5],
-            [16, 8],
-            [17, 10]
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [12, "#1a1a1a"],
-            [14, "#232323"]
+            [
+              12,
+              "#1a1a1a"
+            ],
+            [
+              14,
+              "#232323"
+            ]
           ]
         }
       }
@@ -823,24 +1875,63 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 2],
-            [13, 3],
-            [14, 4],
-            [15, 5],
-            [16, 8],
-            [17, 10]
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [12, "#1a1a1a"],
-            [14, "#232323"]
+            [
+              12,
+              "#1a1a1a"
+            ],
+            [
+              14,
+              "#232323"
+            ]
           ]
         }
       }
@@ -852,27 +1943,75 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.9],
-            [12, 1.5],
-            [13, 3],
-            [14, 5],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              1.5
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [11, "rgba(65, 71, 88, 1)"],
-            [12.99, "rgba(65, 71, 88, 1)"],
-            [13, "rgba(65, 71, 88, 1)"]
+            [
+              11,
+              "#1a1a1a"
+            ],
+            [
+              12.99,
+              "#1a1a1a"
+            ],
+            [
+              13,
+              "#232323"
+            ]
           ]
         }
       }
@@ -884,33 +2023,94 @@
       "source-layer": "transportation",
       "minzoom": 7,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [7, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              7,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -922,33 +2122,94 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [5, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              5,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -960,34 +2221,98 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.7],
-            [8, 0.8],
-            [11, 3],
-            [12, 4],
-            [13, 5],
-            [14, 7],
-            [15, 9],
-            [16, 11],
-            [17, 13],
-            [18, 22]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.7
+            ],
+            [
+              8,
+              0.8
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              12,
+              4
+            ],
+            [
+              13,
+              5
+            ],
+            [
+              14,
+              7
+            ],
+            [
+              15,
+              9
+            ],
+            [
+              16,
+              11
+            ],
+            [
+              17,
+              13
+            ],
+            [
+              18,
+              22
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [6, 0.5],
-            [7, 1]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [5, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              5,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -999,22 +2324,58 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "path", "track"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "path",
+          "track"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [18, 3]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              3
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": "#262626",
         "line-dasharray": {
           "stops": [
-            [15, [2, 2]],
-            [18, [3, 3]]
+            [
+              15,
+              [
+                2,
+                2
+              ]
+            ],
+            [
+              18,
+              [
+                3,
+                3
+              ]
+            ]
           ]
         }
       }
@@ -1026,15 +2387,41 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 2],
-            [16, 2],
-            [17, 4],
-            [18, 6]
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              17,
+              4
+            ],
+            [
+              18,
+              6
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1048,19 +2435,45 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 3],
-            [16, 4],
-            [17, 8],
-            [18, 12]
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              17,
+              8
+            ],
+            [
+              18,
+              12
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1070,17 +2483,50 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 1],
-            [13, 1.5],
-            [14, 2],
-            [15, 3],
-            [16, 6],
-            [17, 8]
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1094,17 +2540,50 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "square", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "square",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 1],
-            [13, 1.5],
-            [14, 2],
-            [15, 3],
-            [16, 6],
-            [17, 8]
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1118,21 +2597,54 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 1],
-            [13, 1.5],
-            [14, 2],
-            [15, 3],
-            [16, 6],
-            [17, 8]
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1142,22 +2654,58 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 2],
-            [13, 2],
-            [14, 3],
-            [15, 4],
-            [16, 6],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              2
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              3
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1167,22 +2715,62 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [10, 0.3],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              10,
+              0.3
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(83, 86, 102, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1192,22 +2780,62 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1217,23 +2845,66 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [10, 1],
-            [12, 2],
-            [13, 3],
-            [14, 5],
-            [15, 7],
-            [16, 9],
-            [17, 11],
-            [18, 20]
+            [
+              10,
+              1
+            ],
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              7
+            ],
+            [
+              16,
+              9
+            ],
+            [
+              17,
+              11
+            ],
+            [
+              18,
+              20
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(73, 73, 73, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1242,18 +2913,48 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
           "base": 1.3,
           "stops": [
-            [13, 0.5],
-            [14, 1],
-            [15, 1],
-            [16, 3],
-            [21, 7]
+            [
+              13,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              21,
+              7
+            ]
           ]
         }
       }
@@ -1264,22 +2965,58 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 15,
-      "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "#111",
         "line-width": {
           "base": 1.3,
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [20, 5]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              20,
+              5
+            ]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [15, [5, 5]],
-            [16, [6, 6]]
+            [
+              15,
+              [
+                5,
+                5
+              ]
+            ],
+            [
+              16,
+              [
+                6,
+                6
+              ]
+            ]
           ]
         }
       }
@@ -1291,15 +3028,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 1],
-            [16, 3],
-            [17, 6],
-            [18, 8]
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              17,
+              6
+            ],
+            [
+              18,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1313,26 +3077,72 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "miter" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 0.5],
-            [14, 2],
-            [15, 3],
-            [16, 4.3],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4.3
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
+        "line-opacity": 1,
         "line-color": {
           "stops": [
-            [13, "#161616"],
-            [15.7, "#161616"],
-            [16, "#1c1c1c"]
+            [
+              13,
+              "#161616"
+            ],
+            [
+              15.7,
+              "#161616"
+            ],
+            [
+              16,
+              "#1c1c1c"
+            ]
           ]
         }
       }
@@ -1344,27 +3154,76 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "miter" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 1.5],
-            [13, 3],
-            [14, 5],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              1.5
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [11, "#1a1a1a"],
-            [12.99, "#1a1a1a"],
-            [13, "#232323"]
+            [
+              11,
+              "#1a1a1a"
+            ],
+            [
+              12.99,
+              "#1a1a1a"
+            ],
+            [
+              13,
+              "#232323"
+            ]
           ]
         }
       }
@@ -1376,33 +3235,95 @@
       "source-layer": "transportation",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [8, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              8,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -1414,7 +3335,24 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -1423,28 +3361,70 @@
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [5, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              5,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -1458,37 +3438,97 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "bridge"]
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
       ],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [12, 4],
-            [13, 5],
-            [14, 7],
-            [15, 9],
-            [16, 11],
-            [17, 13],
-            [18, 22]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              12,
+              4
+            ],
+            [
+              13,
+              5
+            ],
+            [
+              14,
+              7
+            ],
+            [
+              15,
+              9
+            ],
+            [
+              16,
+              11
+            ],
+            [
+              17,
+              13
+            ],
+            [
+              18,
+              22
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [6, 0.5],
-            [7, 1]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [5, "#1a1a1a"],
-            [10, "#232323"]
+            [
+              5,
+              "#1a1a1a"
+            ],
+            [
+              10,
+              "#232323"
+            ]
           ]
         }
       }
@@ -1500,22 +3540,58 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "path"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [18, 3]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              3
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": "#262626",
         "line-dasharray": {
           "stops": [
-            [15, [2, 2]],
-            [18, [3, 3]]
+            [
+              15,
+              [
+                2,
+                2
+              ]
+            ],
+            [
+              18,
+              [
+                3,
+                3
+              ]
+            ]
           ]
         }
       }
@@ -1527,15 +3603,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 2],
-            [16, 2],
-            [17, 4],
-            [18, 6]
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              17,
+              4
+            ],
+            [
+              18,
+              6
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1549,15 +3652,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 3],
-            [16, 4],
-            [17, 8],
-            [18, 12]
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              17,
+              8
+            ],
+            [
+              18,
+              12
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1571,18 +3701,55 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 2],
-            [13, 2],
-            [14, 3],
-            [15, 4],
-            [16, 6],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              2
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              3
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1596,18 +3763,59 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1621,7 +3829,24 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -1630,17 +3855,38 @@
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1652,26 +3898,65 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "bridge"]
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
       ],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [10, 1],
-            [12, 2],
-            [13, 3],
-            [14, 5],
-            [15, 7],
-            [16, 9],
-            [17, 11],
-            [18, 20]
+            [
+              10,
+              1
+            ],
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              7
+            ],
+            [
+              16,
+              9
+            ],
+            [
+              17,
+              11
+            ],
+            [
+              18,
+              20
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1679,13 +3964,21 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": { "visibility": "visible" },
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": {
           "base": 1,
           "stops": [
-            [15.5, "transparent"],
-            [16, "transparent"]
+            [
+              15.5,
+              "transparent"
+            ],
+            [
+              16,
+              "transparent"
+            ]
           ]
         },
         "fill-antialias": true
@@ -1696,22 +3989,42 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": { "visibility": "visible" },
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-translate": {
           "base": 1,
           "stops": [
-            [14, [0, 0]],
-            [16, [-2, -2]]
+            [
+              14,
+              [
+                0,
+                0
+              ]
+            ],
+            [
+              16,
+              [
+                -2,
+                -2
+              ]
+            ]
           ]
         },
         "fill-outline-color": "#0e0e0e",
-        "fill-color": "rgba(57, 57, 57, 1)",
+        "fill-color": "#000",
         "fill-opacity": {
           "base": 1,
           "stops": [
-            [13, 0],
-            [16, 1]
+            [
+              13,
+              0
+            ],
+            [
+              16,
+              1
+            ]
           ]
         }
       }
@@ -1723,10 +4036,25 @@
       "source-layer": "boundary",
       "minzoom": 6,
       "maxzoom": 24,
-      "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
-        "line-color": "#2C353C",
+        "line-color": "#0e0e0e",
         "line-opacity": 0.5,
         "line-width": 8,
         "line-offset": 0
@@ -1738,21 +4066,51 @@
       "source": "carto",
       "source-layer": "boundary",
       "minzoom": 0,
-      "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": {
           "stops": [
-            [4, "rgba(92, 94, 94, 1)"],
-            [5, "rgba(96, 96, 96, 1)"],
-            [6, "rgba(102, 102, 102, 1)"]
+            [
+              4,
+              "#222"
+            ],
+            [
+              5,
+              "#292929"
+            ],
+            [
+              6,
+              "#292929"
+            ]
           ]
         },
         "line-opacity": 1,
         "line-width": {
           "stops": [
-            [3, 1],
-            [6, 1.5]
+            [
+              3,
+              1
+            ],
+            [
+              6,
+              1.5
+            ]
           ]
         },
         "line-offset": 0

--- a/mapboxgl/dark-matter.json
+++ b/mapboxgl/dark-matter.json
@@ -1,11 +1,11 @@
 {
   "version": 8,
   "name": "Dark Matter",
-  "metadata": { "maputnik:renderer": "mbgljs" },
+  "metadata": {},
   "sources": {
     "carto": {
       "type": "vector",
-      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json"
+      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json{api_key}"
     }
   },
   "sprite": "https://tiles.basemaps.cartocdn.com/gl/dark-matter-gl-style/sprite",
@@ -14,8 +14,13 @@
     {
       "id": "background",
       "type": "background",
-      "layout": { "visibility": "visible" },
-      "paint": { "background-color": "#0e0e0e", "background-opacity": 1 }
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "background-color": "#0e0e0e",
+        "background-opacity": 1
+      }
     },
     {
       "id": "landcover",
@@ -24,18 +29,45 @@
       "source-layer": "landcover",
       "filter": [
         "any",
-        ["==", "class", "wood"],
-        ["==", "class", "grass"],
-        ["==", "subclass", "recreation_ground"]
+        [
+          "==",
+          "class",
+          "wood"
+        ],
+        [
+          "==",
+          "class",
+          "grass"
+        ],
+        [
+          "==",
+          "subclass",
+          "recreation_ground"
+        ]
       ],
       "paint": {
         "fill-color": {
           "stops": [
-            [8, "#0e0e0e"],
-            [9, "#0e0e0e"],
-            [11, "#0e0e0e"],
-            [13, "#0e0e0e"],
-            [15, "#0e0e0e"]
+            [
+              8,
+              "#0e0e0e"
+            ],
+            [
+              9,
+              "#0e0e0e"
+            ],
+            [
+              11,
+              "#0e0e0e"
+            ],
+            [
+              13,
+              "#0e0e0e"
+            ],
+            [
+              15,
+              "#0e0e0e"
+            ]
           ]
         },
         "fill-opacity": 1
@@ -47,16 +79,40 @@
       "source": "carto",
       "source-layer": "park",
       "minzoom": 9,
-      "filter": ["all", ["==", "class", "national_park"]],
-      "layout": { "visibility": "visible" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "national_park"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": {
           "stops": [
-            [8, "#0e0e0e"],
-            [9, "#0e0e0e"],
-            [11, "#0e0e0e"],
-            [13, "#0e0e0e"],
-            [15, "#0e0e0e"]
+            [
+              8,
+              "#0e0e0e"
+            ],
+            [
+              9,
+              "#0e0e0e"
+            ],
+            [
+              11,
+              "#0e0e0e"
+            ],
+            [
+              13,
+              "#0e0e0e"
+            ],
+            [
+              15,
+              "#0e0e0e"
+            ]
           ]
         },
         "fill-opacity": 1,
@@ -69,23 +125,53 @@
       "source": "carto",
       "source-layer": "park",
       "minzoom": 0,
-      "filter": ["all", ["==", "class", "nature_reserve"]],
-      "layout": { "visibility": "visible" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "nature_reserve"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": {
           "stops": [
-            [8, "#0e0e0e"],
-            [9, "#0e0e0e"],
-            [11, "#0e0e0e"],
-            [13, "#0e0e0e"],
-            [15, "#0e0e0e"]
+            [
+              8,
+              "#0e0e0e"
+            ],
+            [
+              9,
+              "#0e0e0e"
+            ],
+            [
+              11,
+              "#0e0e0e"
+            ],
+            [
+              13,
+              "#0e0e0e"
+            ],
+            [
+              15,
+              "#0e0e0e"
+            ]
           ]
         },
         "fill-antialias": true,
         "fill-opacity": {
           "stops": [
-            [6, 0.7],
-            [9, 0.9]
+            [
+              6,
+              0.7
+            ],
+            [
+              9,
+              0.9
+            ]
           ]
         }
       }
@@ -96,23 +182,57 @@
       "source": "carto",
       "source-layer": "landuse",
       "minzoom": 6,
-      "filter": ["any", ["==", "class", "residential"]],
+      "filter": [
+        "any",
+        [
+          "==",
+          "class",
+          "residential"
+        ]
+      ],
       "paint": {
         "fill-color": {
           "stops": [
-            [5, "rgba(0, 0, 0, 0.5)"],
-            [8, "rgba(0, 0, 0, 0.45)"],
-            [9, "rgba(0, 0, 0, 0.4)"],
-            [11, "rgba(0, 0, 0, 0.35)"],
-            [13, "rgba(0, 0, 0, 0.3)"],
-            [15, "rgba(0, 0, 0, 0.25)"],
-            [16, "rgba(0, 0, 0, 0.15)"]
+            [
+              5,
+              "rgba(0, 0, 0, 0.5)"
+            ],
+            [
+              8,
+              "rgba(0, 0, 0, 0.45)"
+            ],
+            [
+              9,
+              "rgba(0, 0, 0, 0.4)"
+            ],
+            [
+              11,
+              "rgba(0, 0, 0, 0.35)"
+            ],
+            [
+              13,
+              "rgba(0, 0, 0, 0.3)"
+            ],
+            [
+              15,
+              "rgba(0, 0, 0, 0.25)"
+            ],
+            [
+              16,
+              "rgba(0, 0, 0, 0.15)"
+            ]
           ]
         },
         "fill-opacity": {
           "stops": [
-            [6, 0.6],
-            [9, 1]
+            [
+              6,
+              0.6
+            ],
+            [
+              9,
+              1
+            ]
           ]
         }
       }
@@ -122,15 +242,42 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "landuse",
-      "filter": ["any", ["==", "class", "cemetery"], ["==", "class", "stadium"]],
+      "filter": [
+        "any",
+        [
+          "==",
+          "class",
+          "cemetery"
+        ],
+        [
+          "==",
+          "class",
+          "stadium"
+        ]
+      ],
       "paint": {
         "fill-color": {
           "stops": [
-            [8, "#0e0e0e"],
-            [9, "#0e0e0e"],
-            [11, "#0e0e0e"],
-            [13, "#0e0e0e"],
-            [15, "#0e0e0e"]
+            [
+              8,
+              "#0e0e0e"
+            ],
+            [
+              9,
+              "#0e0e0e"
+            ],
+            [
+              11,
+              "#0e0e0e"
+            ],
+            [
+              13,
+              "#0e0e0e"
+            ],
+            [
+              15,
+              "#0e0e0e"
+            ]
           ]
         }
       }
@@ -141,13 +288,25 @@
       "source": "carto",
       "source-layer": "waterway",
       "paint": {
-        "line-color": "rgba(63, 90, 109, 1)",
+        "line-color": "#151515",
         "line-width": {
           "stops": [
-            [8, 0.5],
-            [9, 1],
-            [15, 2],
-            [16, 3]
+            [
+              8,
+              0.5
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              3
+            ]
           ]
         }
       }
@@ -159,25 +318,63 @@
       "source-layer": "boundary",
       "minzoom": 9,
       "maxzoom": 24,
-      "filter": ["all", ["==", "admin_level", 6], ["==", "maritime", 0]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          6
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ],
       "paint": {
         "line-color": {
           "stops": [
-            [4, "#222"],
-            [5, "#222"],
-            [6, "#2C353C"]
+            [
+              4,
+              "#222"
+            ],
+            [
+              5,
+              "#222"
+            ],
+            [
+              6,
+              "#292929"
+            ]
           ]
         },
         "line-width": {
           "stops": [
-            [4, 0.5],
-            [7, 1]
+            [
+              4,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [6, [1]],
-            [7, [2, 2]]
+            [
+              6,
+              [
+                1
+              ]
+            ],
+            [
+              7,
+              [
+                2,
+                2
+              ]
+            ]
           ]
         }
       }
@@ -188,27 +385,71 @@
       "source": "carto",
       "source-layer": "boundary",
       "minzoom": 4,
-      "filter": ["all", ["==", "admin_level", 4], ["==", "maritime", 0]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          4
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ],
       "paint": {
         "line-color": {
           "stops": [
-            [4, "rgba(103, 103, 114, 1)"],
-            [5, "rgba(103, 103, 114, 1)"],
-            [6, "rgba(103, 103, 114, 1)"]
+            [
+              4,
+              "#222"
+            ],
+            [
+              5,
+              "#222"
+            ],
+            [
+              6,
+              "#292929"
+            ]
           ]
         },
         "line-width": {
           "stops": [
-            [4, 0.5],
-            [7, 1],
-            [8, 1],
-            [9, 1.2]
+            [
+              4,
+              0.5
+            ],
+            [
+              7,
+              1
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              9,
+              1.2
+            ]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [6, [1, 2, 3]],
-            [7, [1, 2, 3]]
+            [
+              6,
+              [
+                1
+              ]
+            ],
+            [
+              7,
+              [
+                2,
+                2
+              ]
+            ]
           ]
         }
       }
@@ -220,10 +461,19 @@
       "source-layer": "water",
       "minzoom": 0,
       "maxzoom": 24,
-      "filter": ["all", ["==", "$type", "Polygon"]],
-      "layout": { "visibility": "visible" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
-        "fill-color": "#2C353C",
+        "fill-color": "#212121",
         "fill-antialias": true,
         "fill-translate-anchor": "map",
         "fill-opacity": 1
@@ -235,8 +485,17 @@
       "source": "carto",
       "source-layer": "water",
       "minzoom": 0,
-      "filter": ["all", ["==", "$type", "Polygon"]],
-      "layout": { "visibility": "visible" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "$type",
+          "Polygon"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": "transparent",
         "fill-antialias": true,
@@ -244,10 +503,34 @@
         "fill-opacity": 1,
         "fill-translate": {
           "stops": [
-            [0, [0, 2]],
-            [6, [0, 1]],
-            [14, [0, 1]],
-            [17, [0, 2]]
+            [
+              0,
+              [
+                0,
+                2
+              ]
+            ],
+            [
+              6,
+              [
+                0,
+                1
+              ]
+            ],
+            [
+              14,
+              [
+                0,
+                1
+              ]
+            ],
+            [
+              17,
+              [
+                0,
+                2
+              ]
+            ]
           ]
         }
       }
@@ -258,16 +541,40 @@
       "source": "carto",
       "source-layer": "aeroway",
       "minzoom": 12,
-      "filter": ["all", ["==", "class", "runway"]],
-      "layout": { "line-cap": "square" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "runway"
+        ]
+      ],
+      "layout": {
+        "line-cap": "square"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ]
           ]
         },
         "line-color": "#111"
@@ -279,17 +586,114 @@
       "source": "carto",
       "source-layer": "aeroway",
       "minzoom": 13,
-      "filter": ["all", ["==", "class", "taxiway"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "taxiway"
+        ]
+      ],
       "paint": {
         "line-color": "#111",
         "line-width": {
           "stops": [
-            [13, 0.5],
-            [14, 1],
-            [15, 2],
-            [16, 4]
+            [
+              13,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              4
+            ]
           ]
         }
+      }
+    },
+    {
+      "id": "waterway_label",
+      "type": "symbol",
+      "source": "carto",
+      "source-layer": "waterway",
+      "filter": [
+        "all",
+        [
+          "has",
+          "name"
+        ],
+        [
+          "==",
+          "class",
+          "river"
+        ]
+      ],
+      "layout": {
+        "text-field": "{name_en}",
+        "text-font": [
+          "Montserrat Regular Italic",
+          "Open Sans Italic",
+          "Noto Sans Regular",
+          "HanWangHeiLight Regular",
+          "NanumBarunGothic Regular"
+        ],
+        "symbol-placement": "line",
+        "symbol-spacing": 300,
+        "symbol-avoid-edges": false,
+        "text-size": {
+          "stops": [
+            [
+              9,
+              8
+            ],
+            [
+              10,
+              9
+            ]
+          ]
+        },
+        "text-padding": 2,
+        "text-pitch-alignment": "auto",
+        "text-rotation-alignment": "auto",
+        "text-offset": {
+          "stops": [
+            [
+              6,
+              [
+                0,
+                -0.2
+              ]
+            ],
+            [
+              11,
+              [
+                0,
+                -0.4
+              ]
+            ],
+            [
+              12,
+              [
+                0,
+                -0.6
+              ]
+            ]
+          ]
+        },
+        "text-letter-spacing": 0,
+        "text-keep-upright": true
+      },
+      "paint": {
+        "text-color": "#444",
+        "text-halo-color": "#181818",
+        "text-halo-width": 1
       }
     },
     {
@@ -299,15 +703,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 1],
-            [16, 3],
-            [17, 6],
-            [18, 8]
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              17,
+              6
+            ],
+            [
+              18,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -321,18 +752,54 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "butt", "line-join": "miter" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 0.5],
-            [14, 2],
-            [15, 4],
-            [16, 6],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
@@ -346,19 +813,59 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 1],
-            [13, 2],
-            [14, 5],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
@@ -372,27 +879,83 @@
       "source-layer": "transportation",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": "#1a1a1a"
@@ -405,7 +968,24 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -414,22 +994,58 @@
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": "#232323"
@@ -444,31 +1060,85 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "tunnel"]
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
       ],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [12, 4],
-            [13, 5],
-            [14, 7],
-            [15, 9],
-            [16, 11],
-            [17, 13],
-            [18, 22]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              12,
+              4
+            ],
+            [
+              13,
+              5
+            ],
+            [
+              14,
+              7
+            ],
+            [
+              15,
+              9
+            ],
+            [
+              16,
+              11
+            ],
+            [
+              17,
+              13
+            ],
+            [
+              18,
+              22
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [6, 0.5],
-            [7, 1]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": "#232323"
@@ -481,22 +1151,58 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "path"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [18, 3]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              3
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": "#262626",
         "line-dasharray": {
           "stops": [
-            [15, [2, 2]],
-            [18, [3, 3]]
+            [
+              15,
+              [
+                2,
+                2
+              ]
+            ],
+            [
+              18,
+              [
+                3,
+                3
+              ]
+            ]
           ]
         }
       }
@@ -508,15 +1214,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 2],
-            [16, 2],
-            [17, 4],
-            [18, 6]
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              17,
+              4
+            ],
+            [
+              18,
+              6
+            ]
           ]
         },
         "line-opacity": 1,
@@ -530,19 +1263,46 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 3],
-            [16, 4],
-            [17, 8],
-            [18, 12]
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              17,
+              8
+            ],
+            [
+              18,
+              12
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(22, 22, 22, 1)"
+        "line-color": "rgba(238, 238, 238, 1)"
       }
     },
     {
@@ -552,18 +1312,55 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 2],
-            [13, 2],
-            [14, 3],
-            [15, 4],
-            [16, 6],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              2
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              3
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
@@ -577,22 +1374,63 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#161616"
       }
     },
     {
@@ -602,7 +1440,24 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "tunnel"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
       "layout": {
         "line-cap": "round",
         "line-join": "round",
@@ -611,13 +1466,34 @@
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
@@ -633,26 +1509,65 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "tunnel"]
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
       ],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [10, 1],
-            [12, 2],
-            [13, 3],
-            [14, 5],
-            [15, 7],
-            [16, 9],
-            [17, 11],
-            [18, 20]
+            [
+              10,
+              1
+            ],
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              7
+            ],
+            [
+              16,
+              9
+            ],
+            [
+              17,
+              11
+            ],
+            [
+              18,
+              20
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#161616"
       }
     },
     {
@@ -661,18 +1576,48 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
           "base": 1.3,
           "stops": [
-            [13, 0.5],
-            [14, 1],
-            [15, 1],
-            [16, 3],
-            [21, 7]
+            [
+              13,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              21,
+              7
+            ]
           ]
         },
         "line-opacity": 0.5
@@ -684,22 +1629,58 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 15,
-      "filter": ["all", ["==", "class", "rail"], ["==", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "==",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "#111",
         "line-width": {
           "base": 1.3,
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [20, 5]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              20,
+              5
+            ]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [15, [5, 5]],
-            [16, [6, 6]]
+            [
+              15,
+              [
+                5,
+                5
+              ]
+            ],
+            [
+              16,
+              [
+                6,
+                6
+              ]
+            ]
           ]
         },
         "line-opacity": 0.5
@@ -712,15 +1693,41 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 1],
-            [16, 3],
-            [17, 6],
-            [18, 8]
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              17,
+              6
+            ],
+            [
+              18,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -734,26 +1741,71 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 0.5],
-            [14, 2],
-            [15, 3],
-            [16, 4.3],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4.3
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
+        "line-opacity": 1,
         "line-color": {
           "stops": [
-            [13, "rgba(65, 71, 88, 1)"],
-            [15.7, "rgba(65, 71, 88, 1)"],
-            [16, "rgba(65, 71, 88, 1)"]
+            [
+              13,
+              "#161616"
+            ],
+            [
+              15.7,
+              "#161616"
+            ],
+            [
+              16,
+              "#1c1c1c"
+            ]
           ]
         }
       }
@@ -765,23 +1817,62 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 2],
-            [13, 3],
-            [14, 4],
-            [15, 5],
-            [16, 8],
-            [17, 10]
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": "#232323"
@@ -794,24 +1885,63 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 2],
-            [13, 3],
-            [14, 4],
-            [15, 5],
-            [16, 8],
-            [17, 10]
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [12, "#1a1a1a"],
-            [14, "#232323"]
+            [
+              12,
+              "#1a1a1a"
+            ],
+            [
+              14,
+              "#232323"
+            ]
           ]
         }
       }
@@ -823,24 +1953,63 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 2],
-            [13, 3],
-            [14, 4],
-            [15, 5],
-            [16, 8],
-            [17, 10]
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              5
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              10
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [12, "#1a1a1a"],
-            [14, "#232323"]
+            [
+              12,
+              "#1a1a1a"
+            ],
+            [
+              14,
+              "#232323"
+            ]
           ]
         }
       }
@@ -852,27 +2021,75 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.9],
-            [12, 1.5],
-            [13, 3],
-            [14, 5],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              1.5
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [11, "rgba(65, 71, 88, 1)"],
-            [12.99, "rgba(65, 71, 88, 1)"],
-            [13, "rgba(65, 71, 88, 1)"]
+            [
+              11,
+              "#1a1a1a"
+            ],
+            [
+              12.99,
+              "#1a1a1a"
+            ],
+            [
+              13,
+              "#232323"
+            ]
           ]
         }
       }
@@ -884,33 +2101,94 @@
       "source-layer": "transportation",
       "minzoom": 7,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [7, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              7,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -922,33 +2200,94 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [5, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              5,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -960,34 +2299,98 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.7],
-            [8, 0.8],
-            [11, 3],
-            [12, 4],
-            [13, 5],
-            [14, 7],
-            [15, 9],
-            [16, 11],
-            [17, 13],
-            [18, 22]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.7
+            ],
+            [
+              8,
+              0.8
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              12,
+              4
+            ],
+            [
+              13,
+              5
+            ],
+            [
+              14,
+              7
+            ],
+            [
+              15,
+              9
+            ],
+            [
+              16,
+              11
+            ],
+            [
+              17,
+              13
+            ],
+            [
+              18,
+              22
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [6, 0.5],
-            [7, 1]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [5, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              5,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -999,22 +2402,58 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "path", "track"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "path",
+          "track"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [18, 3]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              3
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": "#262626",
         "line-dasharray": {
           "stops": [
-            [15, [2, 2]],
-            [18, [3, 3]]
+            [
+              15,
+              [
+                2,
+                2
+              ]
+            ],
+            [
+              18,
+              [
+                3,
+                3
+              ]
+            ]
           ]
         }
       }
@@ -1026,15 +2465,41 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 2],
-            [16, 2],
-            [17, 4],
-            [18, 6]
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              17,
+              4
+            ],
+            [
+              18,
+              6
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1048,19 +2513,45 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 3],
-            [16, 4],
-            [17, 8],
-            [18, 12]
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              17,
+              8
+            ],
+            [
+              18,
+              12
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1070,17 +2561,50 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 1],
-            [13, 1.5],
-            [14, 2],
-            [15, 3],
-            [16, 6],
-            [17, 8]
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1094,17 +2618,50 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "square", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "square",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 1],
-            [13, 1.5],
-            [14, 2],
-            [15, 3],
-            [16, 6],
-            [17, 8]
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1118,21 +2675,54 @@
       "source-layer": "transportation",
       "minzoom": 12,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "motorway"], ["==", "ramp", 1]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "==",
+          "ramp",
+          1
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [12, 1],
-            [13, 1.5],
-            [14, 2],
-            [15, 3],
-            [16, 6],
-            [17, 8]
+            [
+              12,
+              1
+            ],
+            [
+              13,
+              1.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1142,22 +2732,58 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 2],
-            [13, 2],
-            [14, 3],
-            [15, 4],
-            [16, 6],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              2
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              3
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1167,22 +2793,62 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [10, 0.3],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              10,
+              0.3
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(83, 86, 102, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1192,22 +2858,62 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1217,23 +2923,66 @@
       "source-layer": "transportation",
       "minzoom": 10,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "motorway"], ["!=", "ramp", 1], ["!has", "brunnel"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "!has",
+          "brunnel"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [10, 1],
-            [12, 2],
-            [13, 3],
-            [14, 5],
-            [15, 7],
-            [16, 9],
-            [17, 11],
-            [18, 20]
+            [
+              10,
+              1
+            ],
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              7
+            ],
+            [
+              16,
+              9
+            ],
+            [
+              17,
+              11
+            ],
+            [
+              18,
+              20
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(73, 73, 73, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1242,18 +2991,48 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 13,
-      "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "#1a1a1a",
         "line-width": {
           "base": 1.3,
           "stops": [
-            [13, 0.5],
-            [14, 1],
-            [15, 1],
-            [16, 3],
-            [21, 7]
+            [
+              13,
+              0.5
+            ],
+            [
+              14,
+              1
+            ],
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              21,
+              7
+            ]
           ]
         }
       }
@@ -1264,22 +3043,58 @@
       "source": "carto",
       "source-layer": "transportation",
       "minzoom": 15,
-      "filter": ["all", ["==", "class", "rail"], ["!=", "brunnel", "tunnel"]],
-      "layout": { "visibility": "visible", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "rail"
+        ],
+        [
+          "!=",
+          "brunnel",
+          "tunnel"
+        ]
+      ],
+      "layout": {
+        "visibility": "visible",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": "#111",
         "line-width": {
           "base": 1.3,
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [20, 5]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              20,
+              5
+            ]
           ]
         },
         "line-dasharray": {
           "stops": [
-            [15, [5, 5]],
-            [16, [6, 6]]
+            [
+              15,
+              [
+                5,
+                5
+              ]
+            ],
+            [
+              16,
+              [
+                6,
+                6
+              ]
+            ]
           ]
         }
       }
@@ -1291,15 +3106,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 1],
-            [16, 3],
-            [17, 6],
-            [18, 8]
+            [
+              15,
+              1
+            ],
+            [
+              16,
+              3
+            ],
+            [
+              17,
+              6
+            ],
+            [
+              18,
+              8
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1313,26 +3155,72 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "miter" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 0.5],
-            [14, 2],
-            [15, 3],
-            [16, 4.3],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              0.5
+            ],
+            [
+              14,
+              2
+            ],
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4.3
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
+        "line-opacity": 1,
         "line-color": {
           "stops": [
-            [13, "#161616"],
-            [15.7, "#161616"],
-            [16, "#1c1c1c"]
+            [
+              13,
+              "#161616"
+            ],
+            [
+              15.7,
+              "#161616"
+            ],
+            [
+              16,
+              "#1c1c1c"
+            ]
           ]
         }
       }
@@ -1344,27 +3232,76 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "miter" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "miter"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 0.5],
-            [12, 1.5],
-            [13, 3],
-            [14, 5],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              0.5
+            ],
+            [
+              12,
+              1.5
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": {
           "stops": [
-            [11, "#1a1a1a"],
-            [12.99, "#1a1a1a"],
-            [13, "#232323"]
+            [
+              11,
+              "#1a1a1a"
+            ],
+            [
+              12.99,
+              "#1a1a1a"
+            ],
+            [
+              13,
+              "#232323"
+            ]
           ]
         }
       }
@@ -1376,33 +3313,95 @@
       "source-layer": "transportation",
       "minzoom": 8,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [8, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              8,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -1414,7 +3413,24 @@
       "source-layer": "transportation",
       "minzoom": 5,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -1423,28 +3439,70 @@
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [13, 4],
-            [14, 6],
-            [15, 8],
-            [16, 10],
-            [17, 14],
-            [18, 18]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              13,
+              4
+            ],
+            [
+              14,
+              6
+            ],
+            [
+              15,
+              8
+            ],
+            [
+              16,
+              10
+            ],
+            [
+              17,
+              14
+            ],
+            [
+              18,
+              18
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [5, 0.5],
-            [7, 1]
+            [
+              5,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [5, "#1a1a1a"],
-            [12, "#232323"]
+            [
+              5,
+              "#1a1a1a"
+            ],
+            [
+              12,
+              "#232323"
+            ]
           ]
         }
       }
@@ -1458,37 +3516,97 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "bridge"]
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
       ],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [6, 0.5],
-            [7, 0.8],
-            [8, 1],
-            [11, 3],
-            [12, 4],
-            [13, 5],
-            [14, 7],
-            [15, 9],
-            [16, 11],
-            [17, 13],
-            [18, 22]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              0.8
+            ],
+            [
+              8,
+              1
+            ],
+            [
+              11,
+              3
+            ],
+            [
+              12,
+              4
+            ],
+            [
+              13,
+              5
+            ],
+            [
+              14,
+              7
+            ],
+            [
+              15,
+              9
+            ],
+            [
+              16,
+              11
+            ],
+            [
+              17,
+              13
+            ],
+            [
+              18,
+              22
+            ]
           ]
         },
         "line-opacity": {
           "stops": [
-            [6, 0.5],
-            [7, 1]
+            [
+              6,
+              0.5
+            ],
+            [
+              7,
+              1
+            ]
           ]
         },
         "line-color": {
           "stops": [
-            [5, "#1a1a1a"],
-            [10, "#232323"]
+            [
+              5,
+              "#1a1a1a"
+            ],
+            [
+              10,
+              "#232323"
+            ]
           ]
         }
       }
@@ -1500,22 +3618,58 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "path"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "path"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 0.5],
-            [16, 1],
-            [18, 3]
+            [
+              15,
+              0.5
+            ],
+            [
+              16,
+              1
+            ],
+            [
+              18,
+              3
+            ]
           ]
         },
         "line-opacity": 1,
         "line-color": "#262626",
         "line-dasharray": {
           "stops": [
-            [15, [2, 2]],
-            [18, [3, 3]]
+            [
+              15,
+              [
+                2,
+                2
+              ]
+            ],
+            [
+              18,
+              [
+                3,
+                3
+              ]
+            ]
           ]
         }
       }
@@ -1527,15 +3681,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "service"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "service"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 2],
-            [16, 2],
-            [17, 4],
-            [18, 6]
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              2
+            ],
+            [
+              17,
+              4
+            ],
+            [
+              18,
+              6
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1549,15 +3730,42 @@
       "source-layer": "transportation",
       "minzoom": 15,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "minor"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "minor"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [15, 3],
-            [16, 4],
-            [17, 8],
-            [18, 12]
+            [
+              15,
+              3
+            ],
+            [
+              16,
+              4
+            ],
+            [
+              17,
+              8
+            ],
+            [
+              18,
+              12
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1571,18 +3779,55 @@
       "source-layer": "transportation",
       "minzoom": 13,
       "maxzoom": 24,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 2],
-            [13, 2],
-            [14, 3],
-            [15, 4],
-            [16, 6],
-            [17, 10],
-            [18, 14]
+            [
+              11,
+              2
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              3
+            ],
+            [
+              15,
+              4
+            ],
+            [
+              16,
+              6
+            ],
+            [
+              17,
+              10
+            ],
+            [
+              18,
+              14
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1596,18 +3841,59 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "primary"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "primary"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
@@ -1621,7 +3907,24 @@
       "source-layer": "transportation",
       "minzoom": 11,
       "maxzoom": 24,
-      "filter": ["all", ["==", "class", "trunk"], ["!=", "ramp", 1], ["==", "brunnel", "bridge"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "trunk"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
+      ],
       "layout": {
         "line-cap": "butt",
         "line-join": "round",
@@ -1630,17 +3933,38 @@
       "paint": {
         "line-width": {
           "stops": [
-            [11, 1],
-            [13, 2],
-            [14, 4],
-            [15, 6],
-            [16, 8],
-            [17, 12],
-            [18, 16]
+            [
+              11,
+              1
+            ],
+            [
+              13,
+              2
+            ],
+            [
+              14,
+              4
+            ],
+            [
+              15,
+              6
+            ],
+            [
+              16,
+              8
+            ],
+            [
+              17,
+              12
+            ],
+            [
+              18,
+              16
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1652,26 +3976,65 @@
       "maxzoom": 24,
       "filter": [
         "all",
-        ["==", "class", "motorway"],
-        ["!=", "ramp", 1],
-        ["==", "brunnel", "bridge"]
+        [
+          "==",
+          "class",
+          "motorway"
+        ],
+        [
+          "!=",
+          "ramp",
+          1
+        ],
+        [
+          "==",
+          "brunnel",
+          "bridge"
+        ]
       ],
-      "layout": { "line-cap": "butt", "line-join": "round" },
+      "layout": {
+        "line-cap": "butt",
+        "line-join": "round"
+      },
       "paint": {
         "line-width": {
           "stops": [
-            [10, 1],
-            [12, 2],
-            [13, 3],
-            [14, 5],
-            [15, 7],
-            [16, 9],
-            [17, 11],
-            [18, 20]
+            [
+              10,
+              1
+            ],
+            [
+              12,
+              2
+            ],
+            [
+              13,
+              3
+            ],
+            [
+              14,
+              5
+            ],
+            [
+              15,
+              7
+            ],
+            [
+              16,
+              9
+            ],
+            [
+              17,
+              11
+            ],
+            [
+              18,
+              20
+            ]
           ]
         },
         "line-opacity": 1,
-        "line-color": "rgba(65, 71, 88, 1)"
+        "line-color": "#0b0b0b"
       }
     },
     {
@@ -1679,13 +4042,21 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": { "visibility": "visible" },
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-color": {
           "base": 1,
           "stops": [
-            [15.5, "transparent"],
-            [16, "transparent"]
+            [
+              15.5,
+              "transparent"
+            ],
+            [
+              16,
+              "transparent"
+            ]
           ]
         },
         "fill-antialias": true
@@ -1696,22 +4067,42 @@
       "type": "fill",
       "source": "carto",
       "source-layer": "building",
-      "layout": { "visibility": "visible" },
+      "layout": {
+        "visibility": "visible"
+      },
       "paint": {
         "fill-translate": {
           "base": 1,
           "stops": [
-            [14, [0, 0]],
-            [16, [-2, -2]]
+            [
+              14,
+              [
+                0,
+                0
+              ]
+            ],
+            [
+              16,
+              [
+                -2,
+                -2
+              ]
+            ]
           ]
         },
         "fill-outline-color": "#0e0e0e",
-        "fill-color": "rgba(57, 57, 57, 1)",
+        "fill-color": "#000",
         "fill-opacity": {
           "base": 1,
           "stops": [
-            [13, 0],
-            [16, 1]
+            [
+              13,
+              0
+            ],
+            [
+              16,
+              1
+            ]
           ]
         }
       }
@@ -1723,10 +4114,25 @@
       "source-layer": "boundary",
       "minzoom": 6,
       "maxzoom": 24,
-      "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
-        "line-color": "#2C353C",
+        "line-color": "#0e0e0e",
         "line-opacity": 0.5,
         "line-width": 8,
         "line-offset": 0
@@ -1738,67 +4144,54 @@
       "source": "carto",
       "source-layer": "boundary",
       "minzoom": 0,
-      "filter": ["all", ["==", "admin_level", 2], ["==", "maritime", 0]],
-      "layout": { "line-cap": "round", "line-join": "round" },
+      "filter": [
+        "all",
+        [
+          "==",
+          "admin_level",
+          2
+        ],
+        [
+          "==",
+          "maritime",
+          0
+        ]
+      ],
+      "layout": {
+        "line-cap": "round",
+        "line-join": "round"
+      },
       "paint": {
         "line-color": {
           "stops": [
-            [4, "rgba(92, 94, 94, 1)"],
-            [5, "rgba(96, 96, 96, 1)"],
-            [6, "rgba(102, 102, 102, 1)"]
+            [
+              4,
+              "#222"
+            ],
+            [
+              5,
+              "#292929"
+            ],
+            [
+              6,
+              "#292929"
+            ]
           ]
         },
         "line-opacity": 1,
         "line-width": {
           "stops": [
-            [3, 1],
-            [6, 1.5]
+            [
+              3,
+              1
+            ],
+            [
+              6,
+              1.5
+            ]
           ]
         },
         "line-offset": 0
-      }
-    },
-    {
-      "id": "waterway_label",
-      "type": "symbol",
-      "source": "carto",
-      "source-layer": "waterway",
-      "filter": ["all", ["has", "name"], ["==", "class", "river"]],
-      "layout": {
-        "text-field": "{name_en}",
-        "text-font": [
-          "Montserrat Regular Italic",
-          "Open Sans Italic",
-          "Noto Sans Regular",
-          "HanWangHeiLight Regular",
-          "NanumBarunGothic Regular"
-        ],
-        "symbol-placement": "line",
-        "symbol-spacing": 300,
-        "symbol-avoid-edges": false,
-        "text-size": {
-          "stops": [
-            [9, 8],
-            [10, 9]
-          ]
-        },
-        "text-padding": 2,
-        "text-pitch-alignment": "auto",
-        "text-rotation-alignment": "auto",
-        "text-offset": {
-          "stops": [
-            [6, [0, -0.2]],
-            [11, [0, -0.4]],
-            [12, [0, -0.6]]
-          ]
-        },
-        "text-letter-spacing": 0,
-        "text-keep-upright": true
-      },
-      "paint": {
-        "text-color": "rgba(164, 164, 164, 1)",
-        "text-halo-color": "#181818",
-        "text-halo-width": 1
       }
     },
     {
@@ -1808,15 +4201,40 @@
       "source-layer": "water_name",
       "minzoom": 0,
       "maxzoom": 5,
-      "filter": ["all", ["has", "name"], ["==", "$type", "Point"], ["==", "class", "ocean"]],
+      "filter": [
+        "all",
+        [
+          "has",
+          "name"
+        ],
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "==",
+          "class",
+          "ocean"
+        ]
+      ],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "point",
         "text-size": {
           "stops": [
-            [0, 13],
-            [2, 14],
-            [4, 18]
+            [
+              0,
+              13
+            ],
+            [
+              2,
+              14
+            ],
+            [
+              4,
+              18
+            ]
           ]
         },
         "text-font": [
@@ -1836,7 +4254,7 @@
         "text-letter-spacing": 0.1
       },
       "paint": {
-        "text-color": "rgba(109, 123, 129, 1)",
+        "text-color": "#3c3c3c",
         "text-halo-color": "rgba(0,0,0,0.7)",
         "text-halo-width": 1,
         "text-halo-blur": 0
@@ -1848,7 +4266,23 @@
       "source": "carto",
       "source-layer": "water_name",
       "minzoom": 5,
-      "filter": ["all", ["has", "name"], ["==", "$type", "Point"], ["==", "class", "sea"]],
+      "filter": [
+        "all",
+        [
+          "has",
+          "name"
+        ],
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "==",
+          "class",
+          "sea"
+        ]
+      ],
       "layout": {
         "text-field": "{name}",
         "symbol-placement": "point",
@@ -1882,22 +4316,59 @@
       "source": "carto",
       "source-layer": "water_name",
       "minzoom": 4,
-      "filter": ["all", ["has", "name"], ["==", "$type", "Point"], ["==", "class", "lake"]],
+      "filter": [
+        "all",
+        [
+          "has",
+          "name"
+        ],
+        [
+          "==",
+          "$type",
+          "Point"
+        ],
+        [
+          "==",
+          "class",
+          "lake"
+        ]
+      ],
       "layout": {
         "text-field": {
           "stops": [
-            [8, "{name_en}"],
-            [13, "{name}"]
+            [
+              8,
+              "{name_en}"
+            ],
+            [
+              13,
+              "{name}"
+            ]
           ]
         },
         "symbol-placement": "point",
         "text-size": {
           "stops": [
-            [13, 9],
-            [14, 10],
-            [15, 11],
-            [16, 12],
-            [17, 13]
+            [
+              13,
+              9
+            ],
+            [
+              14,
+              10
+            ],
+            [
+              15,
+              11
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              17,
+              13
+            ]
           ]
         },
         "text-font": [
@@ -1915,7 +4386,7 @@
         "text-rotation-alignment": "auto"
       },
       "paint": {
-        "text-color": "rgba(155, 155, 155, 1)",
+        "text-color": "#444",
         "text-halo-color": "#181818",
         "text-halo-width": 1,
         "text-halo-blur": 1
@@ -1926,22 +4397,54 @@
       "type": "symbol",
       "source": "carto",
       "source-layer": "water_name",
-      "filter": ["all", ["has", "name"], ["==", "$type", "LineString"]],
+      "filter": [
+        "all",
+        [
+          "has",
+          "name"
+        ],
+        [
+          "==",
+          "$type",
+          "LineString"
+        ]
+      ],
       "layout": {
         "text-field": {
           "stops": [
-            [8, "{name_en}"],
-            [13, "{name}"]
+            [
+              8,
+              "{name_en}"
+            ],
+            [
+              13,
+              "{name}"
+            ]
           ]
         },
         "symbol-placement": "line",
         "text-size": {
           "stops": [
-            [13, 9],
-            [14, 10],
-            [15, 11],
-            [16, 12],
-            [17, 13]
+            [
+              13,
+              9
+            ],
+            [
+              14,
+              10
+            ],
+            [
+              15,
+              11
+            ],
+            [
+              16,
+              12
+            ],
+            [
+              17,
+              13
+            ]
           ]
         },
         "text-font": [
@@ -1970,12 +4473,30 @@
       "source-layer": "place",
       "minzoom": 12,
       "maxzoom": 16,
-      "filter": ["any", ["==", "class", "neighbourhood"], ["==", "class", "hamlet"]],
+      "filter": [
+        "any",
+        [
+          "==",
+          "class",
+          "neighbourhood"
+        ],
+        [
+          "==",
+          "class",
+          "hamlet"
+        ]
+      ],
       "layout": {
         "text-field": {
           "stops": [
-            [8, "{name_en}"],
-            [14, "{name}"]
+            [
+              8,
+              "{name_en}"
+            ],
+            [
+              14,
+              "{name}"
+            ]
           ]
         },
         "text-font": [
@@ -1987,30 +4508,51 @@
         ],
         "text-size": {
           "stops": [
-            [13, 8],
-            [14, 10],
-            [16, 11]
+            [
+              13,
+              8
+            ],
+            [
+              14,
+              10
+            ],
+            [
+              16,
+              11
+            ]
           ]
         },
         "icon-image": "",
-        "icon-offset": [16, 0],
+        "icon-offset": [
+          16,
+          0
+        ],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2],
+        "text-offset": [
+          0.2,
+          0.2
+        ],
         "text-transform": {
           "stops": [
-            [12, "none"],
-            [14, "uppercase"]
+            [
+              12,
+              "none"
+            ],
+            [
+              14,
+              "uppercase"
+            ]
           ]
         }
       },
       "paint": {
-        "text-color": "rgba(182, 180, 180, 1)",
+        "text-color": "#666",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
-        "text-halo-color": "rgba(53, 52, 52, 1)",
+        "text-halo-color": "#222",
         "text-halo-width": 1
       }
     },
@@ -2021,12 +4563,25 @@
       "source-layer": "place",
       "minzoom": 12,
       "maxzoom": 16,
-      "filter": ["all", ["==", "class", "suburb"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "suburb"
+        ]
+      ],
       "layout": {
         "text-field": {
           "stops": [
-            [8, "{name_en}"],
-            [13, "{name}"]
+            [
+              8,
+              "{name_en}"
+            ],
+            [
+              13,
+              "{name}"
+            ]
           ]
         },
         "text-font": [
@@ -2038,24 +4593,51 @@
         ],
         "text-size": {
           "stops": [
-            [12, 9],
-            [13, 10],
-            [14, 11],
-            [15, 12],
-            [16, 13]
+            [
+              12,
+              9
+            ],
+            [
+              13,
+              10
+            ],
+            [
+              14,
+              11
+            ],
+            [
+              15,
+              12
+            ],
+            [
+              16,
+              13
+            ]
           ]
         },
         "icon-image": "",
-        "icon-offset": [16, 0],
+        "icon-offset": [
+          16,
+          0
+        ],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2],
+        "text-offset": [
+          0.2,
+          0.2
+        ],
         "text-transform": {
           "stops": [
-            [8, "none"],
-            [12, "uppercase"]
+            [
+              8,
+              "none"
+            ],
+            [
+              12,
+              "uppercase"
+            ]
           ]
         }
       },
@@ -2074,12 +4656,25 @@
       "source-layer": "place",
       "minzoom": 10,
       "maxzoom": 16,
-      "filter": ["all", ["==", "class", "village"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "village"
+        ]
+      ],
       "layout": {
         "text-field": {
           "stops": [
-            [8, "{name_en}"],
-            [13, "{name}"]
+            [
+              8,
+              "{name_en}"
+            ],
+            [
+              13,
+              "{name}"
+            ]
           ]
         },
         "text-font": [
@@ -2091,24 +4686,45 @@
         ],
         "text-size": {
           "stops": [
-            [10, 9],
-            [12, 10],
-            [13, 11],
-            [14, 12],
-            [16, 13]
+            [
+              10,
+              9
+            ],
+            [
+              12,
+              10
+            ],
+            [
+              13,
+              11
+            ],
+            [
+              14,
+              12
+            ],
+            [
+              16,
+              13
+            ]
           ]
         },
         "icon-image": "",
-        "icon-offset": [16, 0],
+        "icon-offset": [
+          16,
+          0
+        ],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2],
+        "text-offset": [
+          0.2,
+          0.2
+        ],
         "text-transform": "none"
       },
       "paint": {
-        "text-color": "rgba(154, 153, 153, 1)",
+        "text-color": "#666",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -2122,12 +4738,25 @@
       "source-layer": "place",
       "minzoom": 8,
       "maxzoom": 14,
-      "filter": ["all", ["==", "class", "town"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "town"
+        ]
+      ],
       "layout": {
         "text-field": {
           "stops": [
-            [8, "{name_en}"],
-            [13, "{name}"]
+            [
+              8,
+              "{name_en}"
+            ],
+            [
+              13,
+              "{name}"
+            ]
           ]
         },
         "text-font": [
@@ -2139,24 +4768,45 @@
         ],
         "text-size": {
           "stops": [
-            [8, 10],
-            [9, 10],
-            [10, 11],
-            [13, 14],
-            [14, 15]
+            [
+              8,
+              10
+            ],
+            [
+              9,
+              10
+            ],
+            [
+              10,
+              11
+            ],
+            [
+              13,
+              14
+            ],
+            [
+              14,
+              15
+            ]
           ]
         },
         "icon-image": "",
-        "icon-offset": [16, 0],
+        "icon-offset": [
+          16,
+          0
+        ],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2],
+        "text-offset": [
+          0.2,
+          0.2
+        ],
         "text-transform": "none"
       },
       "paint": {
-        "text-color": "rgba(204, 208, 228, 1)",
+        "text-color": "#666",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -2170,7 +4820,23 @@
       "source-layer": "place",
       "minzoom": 3,
       "maxzoom": 10,
-      "filter": ["all", ["==", "class", "country"], [">=", "rank", 3], ["has", "iso_a2"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          ">=",
+          "rank",
+          3
+        ],
+        [
+          "has",
+          "iso_a2"
+        ]
+      ],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2182,11 +4848,26 @@
         ],
         "text-size": {
           "stops": [
-            [3, 10],
-            [5, 11],
-            [6, 12],
-            [7, 13],
-            [8, 14]
+            [
+              3,
+              10
+            ],
+            [
+              5,
+              11
+            ],
+            [
+              6,
+              12
+            ],
+            [
+              7,
+              13
+            ],
+            [
+              8,
+              14
+            ]
           ]
         },
         "text-transform": "uppercase"
@@ -2194,9 +4875,18 @@
       "paint": {
         "text-color": {
           "stops": [
-            [3, "rgba(157, 157, 157, 1)"],
-            [5, "rgba(114, 114, 114, 1)"],
-            [6, "rgba(112, 112, 112, 1)"]
+            [
+              3,
+              "#555"
+            ],
+            [
+              5,
+              "#444"
+            ],
+            [
+              6,
+              "#3a3a3a"
+            ]
           ]
         },
         "text-halo-color": "#111",
@@ -2210,7 +4900,19 @@
       "source-layer": "place",
       "minzoom": 2,
       "maxzoom": 7,
-      "filter": ["all", ["==", "class", "country"], ["<=", "rank", 2]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "country"
+        ],
+        [
+          "<=",
+          "rank",
+          2
+        ]
+      ],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2222,28 +4924,61 @@
         ],
         "text-size": {
           "stops": [
-            [3, 11],
-            [4, 12],
-            [5, 13],
-            [6, 14]
+            [
+              3,
+              11
+            ],
+            [
+              4,
+              12
+            ],
+            [
+              5,
+              13
+            ],
+            [
+              6,
+              14
+            ]
           ]
         },
         "text-transform": "uppercase",
         "text-max-width": {
           "stops": [
-            [2, 6],
-            [3, 6],
-            [4, 9],
-            [5, 12]
+            [
+              2,
+              6
+            ],
+            [
+              3,
+              6
+            ],
+            [
+              4,
+              9
+            ],
+            [
+              5,
+              12
+            ]
           ]
         }
       },
       "paint": {
         "text-color": {
           "stops": [
-            [3, "rgba(158, 182, 189, 1)"],
-            [5, "rgba(118, 126, 137, 1)"],
-            [6, "rgba(120, 141, 147, 1)"]
+            [
+              3,
+              "#555"
+            ],
+            [
+              5,
+              "#444"
+            ],
+            [
+              6,
+              "#3a3a3a"
+            ]
           ]
         },
         "text-halo-color": "#111",
@@ -2257,7 +4992,19 @@
       "source-layer": "place",
       "minzoom": 5,
       "maxzoom": 10,
-      "filter": ["all", ["==", "class", "state"], ["<=", "rank", 4]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "state"
+        ],
+        [
+          "<=",
+          "rank",
+          4
+        ]
+      ],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2269,15 +5016,21 @@
         ],
         "text-size": {
           "stops": [
-            [5, 12],
-            [7, 14]
+            [
+              5,
+              12
+            ],
+            [
+              7,
+              14
+            ]
           ]
         },
         "text-transform": "uppercase",
         "text-max-width": 9
       },
       "paint": {
-        "text-color": "rgba(203, 230, 230, 1)",
+        "text-color": "#444",
         "text-halo-color": "#111",
         "text-halo-width": 0
       }
@@ -2289,7 +5042,14 @@
       "source-layer": "place",
       "minzoom": 0,
       "maxzoom": 2,
-      "filter": ["all", ["==", "class", "continent"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "continent"
+        ]
+      ],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2307,7 +5067,7 @@
         "text-keep-upright": false
       },
       "paint": {
-        "text-color": "rgba(135, 164, 179, 1)",
+        "text-color": "#555",
         "text-halo-color": "#111",
         "text-halo-width": 1
       }
@@ -2319,12 +5079,30 @@
       "source-layer": "place",
       "minzoom": 8,
       "maxzoom": 15,
-      "filter": ["all", ["==", "class", "city"], [">=", "rank", 6]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          ">=",
+          "rank",
+          6
+        ]
+      ],
       "layout": {
         "text-field": {
           "stops": [
-            [8, "{name_en}"],
-            [13, "{name}"]
+            [
+              8,
+              "{name_en}"
+            ],
+            [
+              13,
+              "{name}"
+            ]
           ]
         },
         "text-font": [
@@ -2336,24 +5114,45 @@
         ],
         "text-size": {
           "stops": [
-            [8, 12],
-            [9, 13],
-            [10, 14],
-            [13, 17],
-            [14, 20]
+            [
+              8,
+              12
+            ],
+            [
+              9,
+              13
+            ],
+            [
+              10,
+              14
+            ],
+            [
+              13,
+              17
+            ],
+            [
+              14,
+              20
+            ]
           ]
         },
         "icon-image": "",
-        "icon-offset": [16, 0],
+        "icon-offset": [
+          16,
+          0
+        ],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2],
+        "text-offset": [
+          0.2,
+          0.2
+        ],
         "text-transform": "uppercase"
       },
       "paint": {
-        "text-color": "rgba(168, 176, 180, 1)",
+        "text-color": "#666",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -2367,12 +5166,35 @@
       "source-layer": "place",
       "minzoom": 8,
       "maxzoom": 15,
-      "filter": ["all", ["==", "class", "city"], [">=", "rank", 0], ["<=", "rank", 5]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          ">=",
+          "rank",
+          0
+        ],
+        [
+          "<=",
+          "rank",
+          5
+        ]
+      ],
       "layout": {
         "text-field": {
           "stops": [
-            [8, "{name_en}"],
-            [13, "{name}"]
+            [
+              8,
+              "{name_en}"
+            ],
+            [
+              13,
+              "{name}"
+            ]
           ]
         },
         "text-font": [
@@ -2384,23 +5206,41 @@
         ],
         "text-size": {
           "stops": [
-            [8, 14],
-            [10, 16],
-            [13, 19],
-            [14, 22]
+            [
+              8,
+              14
+            ],
+            [
+              10,
+              16
+            ],
+            [
+              13,
+              19
+            ],
+            [
+              14,
+              22
+            ]
           ]
         },
         "icon-image": "",
-        "icon-offset": [16, 0],
+        "icon-offset": [
+          16,
+          0
+        ],
         "text-anchor": "center",
         "icon-size": 1,
         "text-max-width": 10,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2],
+        "text-offset": [
+          0.2,
+          0.2
+        ],
         "text-transform": "uppercase"
       },
       "paint": {
-        "text-color": "rgba(211, 228, 236, 1)",
+        "text-color": "#666",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -2414,7 +5254,19 @@
       "source-layer": "place",
       "minzoom": 6,
       "maxzoom": 7,
-      "filter": ["all", ["==", "class", "city"], ["<=", "rank", 7]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "<=",
+          "rank",
+          7
+        ]
+      ],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2426,16 +5278,22 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [16, 5],
+        "icon-offset": [
+          16,
+          5
+        ],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2]
+        "text-offset": [
+          0.2,
+          0.2
+        ]
       },
       "paint": {
-        "text-color": "rgba(174, 191, 207, 1)",
-        "icon-color": "rgba(94, 105, 106, 1)",
+        "text-color": "#666",
+        "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
         "text-halo-width": 1
@@ -2448,7 +5306,19 @@
       "source-layer": "place",
       "minzoom": 5,
       "maxzoom": 7,
-      "filter": ["all", ["==", "class", "city"], ["<=", "rank", 4]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "<=",
+          "rank",
+          4
+        ]
+      ],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2460,15 +5330,21 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [16, 5],
+        "icon-offset": [
+          16,
+          5
+        ],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2]
+        "text-offset": [
+          0.2,
+          0.2
+        ]
       },
       "paint": {
-        "text-color": "rgba(233, 239, 246, 1)",
+        "text-color": "#666",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -2482,7 +5358,19 @@
       "source-layer": "place",
       "minzoom": 4,
       "maxzoom": 7,
-      "filter": ["all", ["==", "class", "city"], ["<=", "rank", 2]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "city"
+        ],
+        [
+          "<=",
+          "rank",
+          2
+        ]
+      ],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2494,16 +5382,22 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [16, 5],
+        "icon-offset": [
+          16,
+          5
+        ],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2]
+        "text-offset": [
+          0.2,
+          0.2
+        ]
       },
       "paint": {
-        "text-color": "rgba(175, 194, 217, 1)",
-        "icon-color": "rgba(131, 164, 189, 1)",
+        "text-color": "#666",
+        "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
         "text-halo-width": 1
@@ -2516,7 +5410,19 @@
       "source-layer": "place",
       "minzoom": 7,
       "maxzoom": 8,
-      "filter": ["all", ["!has", "capital"], ["!in", "class", "country", "state"]],
+      "filter": [
+        "all",
+        [
+          "!has",
+          "capital"
+        ],
+        [
+          "!in",
+          "class",
+          "country",
+          "state"
+        ]
+      ],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2528,16 +5434,22 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [16, 5],
+        "icon-offset": [
+          16,
+          5
+        ],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2]
+        "text-offset": [
+          0.2,
+          0.2
+        ]
       },
       "paint": {
-        "text-color": "rgba(160, 179, 191, 1)",
-        "icon-color": "rgba(113, 128, 147, 1)",
+        "text-color": "#666",
+        "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
         "text-halo-width": 1
@@ -2550,7 +5462,14 @@
       "source-layer": "place",
       "minzoom": 7,
       "maxzoom": 8,
-      "filter": ["all", [">", "capital", 0]],
+      "filter": [
+        "all",
+        [
+          ">",
+          "capital",
+          0
+        ]
+      ],
       "layout": {
         "text-field": "{name_en}",
         "text-font": [
@@ -2562,16 +5481,22 @@
         ],
         "text-size": 12,
         "icon-image": "circle-11",
-        "icon-offset": [16, 5],
+        "icon-offset": [
+          16,
+          5
+        ],
         "text-anchor": "right",
         "icon-size": 0.4,
         "text-max-width": 8,
         "text-keep-upright": true,
-        "text-offset": [0.2, 0.2],
+        "text-offset": [
+          0.2,
+          0.2
+        ],
         "text-transform": "uppercase"
       },
       "paint": {
-        "text-color": "rgba(177, 201, 214, 1)",
+        "text-color": "#666",
         "icon-color": "#666",
         "icon-translate-anchor": "map",
         "text-halo-color": "#222",
@@ -2584,7 +5509,21 @@
       "source": "carto",
       "source-layer": "poi",
       "minzoom": 15,
-      "filter": ["all", ["in", "class", "stadium", "cemetery", "attraction"], ["<=", "rank", 3]],
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "stadium",
+          "cemetery",
+          "attraction"
+        ],
+        [
+          "<=",
+          "rank",
+          3
+        ]
+      ],
       "layout": {
         "text-field": "{name}",
         "text-font": [
@@ -2596,9 +5535,18 @@
         ],
         "text-size": {
           "stops": [
-            [15, 8],
-            [17, 9],
-            [18, 10]
+            [
+              15,
+              8
+            ],
+            [
+              17,
+              9
+            ],
+            [
+              18,
+              10
+            ]
           ]
         },
         "text-transform": "uppercase"
@@ -2615,7 +5563,14 @@
       "source": "carto",
       "source-layer": "poi",
       "minzoom": 15,
-      "filter": ["all", ["==", "class", "park"]],
+      "filter": [
+        "all",
+        [
+          "==",
+          "class",
+          "park"
+        ]
+      ],
       "layout": {
         "text-field": "{name}",
         "text-font": [
@@ -2627,9 +5582,18 @@
         ],
         "text-size": {
           "stops": [
-            [15, 8],
-            [17, 9],
-            [18, 10]
+            [
+              15,
+              8
+            ],
+            [
+              17,
+              9
+            ],
+            [
+              18,
+              10
+            ]
           ]
         },
         "text-transform": "uppercase"
@@ -2646,7 +5610,15 @@
       "source": "carto",
       "source-layer": "transportation_name",
       "minzoom": 16,
-      "filter": ["all", ["in", "class", "minor", "service"]],
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "minor",
+          "service"
+        ]
+      ],
       "layout": {
         "symbol-placement": "line",
         "text-font": [
@@ -2665,7 +5637,7 @@
         "text-justify": "center"
       },
       "paint": {
-        "text-color": "rgba(181, 180, 180, 1)",
+        "text-color": "#383838",
         "text-halo-color": "#111",
         "text-halo-width": 1
       }
@@ -2676,7 +5648,15 @@
       "source": "carto",
       "source-layer": "transportation_name",
       "minzoom": 15,
-      "filter": ["all", ["in", "class", "secondary", "tertiary"]],
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "secondary",
+          "tertiary"
+        ]
+      ],
       "layout": {
         "symbol-placement": "line",
         "text-font": [
@@ -2688,9 +5668,18 @@
         ],
         "text-size": {
           "stops": [
-            [15, 9],
-            [16, 11],
-            [18, 12]
+            [
+              15,
+              9
+            ],
+            [
+              16,
+              11
+            ],
+            [
+              18,
+              12
+            ]
           ]
         },
         "text-field": "{name}",
@@ -2701,8 +5690,8 @@
         "text-justify": "center"
       },
       "paint": {
-        "text-color": "rgba(146, 146, 146, 1)",
-        "text-halo-color": "rgba(34, 34, 34, 1)",
+        "text-color": "#383838",
+        "text-halo-color": "#111",
         "text-halo-width": 1
       }
     },
@@ -2712,7 +5701,14 @@
       "source": "carto",
       "source-layer": "transportation_name",
       "minzoom": 14,
-      "filter": ["all", ["in", "class", "primary"]],
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "primary"
+        ]
+      ],
       "layout": {
         "symbol-placement": "line",
         "text-font": [
@@ -2724,18 +5720,36 @@
         ],
         "text-size": {
           "stops": [
-            [14, 10],
-            [15, 10],
-            [16, 11],
-            [18, 12]
+            [
+              14,
+              10
+            ],
+            [
+              15,
+              10
+            ],
+            [
+              16,
+              11
+            ],
+            [
+              18,
+              12
+            ]
           ]
         },
         "text-field": "{name}",
         "symbol-avoid-edges": false,
         "symbol-spacing": {
           "stops": [
-            [6, 200],
-            [16, 250]
+            [
+              6,
+              200
+            ],
+            [
+              16,
+              250
+            ]
           ]
         },
         "text-pitch-alignment": "auto",
@@ -2743,13 +5757,19 @@
         "text-justify": "center",
         "text-letter-spacing": {
           "stops": [
-            [14, 0],
-            [16, 0.2]
+            [
+              14,
+              0
+            ],
+            [
+              16,
+              0.2
+            ]
           ]
         }
       },
       "paint": {
-        "text-color": "rgba(189, 189, 189, 1)",
+        "text-color": "#383838",
         "text-halo-color": "#111",
         "text-halo-width": 1
       }
@@ -2760,7 +5780,15 @@
       "source": "carto",
       "source-layer": "transportation_name",
       "minzoom": 13,
-      "filter": ["all", ["in", "class", "trunk", "motorway"]],
+      "filter": [
+        "all",
+        [
+          "in",
+          "class",
+          "trunk",
+          "motorway"
+        ]
+      ],
       "layout": {
         "symbol-placement": "line",
         "text-font": [
@@ -2772,18 +5800,36 @@
         ],
         "text-size": {
           "stops": [
-            [14, 10],
-            [15, 10],
-            [16, 11],
-            [18, 12]
+            [
+              14,
+              10
+            ],
+            [
+              15,
+              10
+            ],
+            [
+              16,
+              11
+            ],
+            [
+              18,
+              12
+            ]
           ]
         },
         "text-field": "{name}",
         "symbol-avoid-edges": false,
         "symbol-spacing": {
           "stops": [
-            [6, 200],
-            [16, 250]
+            [
+              6,
+              200
+            ],
+            [
+              16,
+              250
+            ]
           ]
         },
         "text-pitch-alignment": "auto",
@@ -2791,8 +5837,14 @@
         "text-justify": "center",
         "text-letter-spacing": {
           "stops": [
-            [13, 0],
-            [16, 0.2]
+            [
+              13,
+              0
+            ],
+            [
+              16,
+              0.2
+            ]
           ]
         }
       },
@@ -2813,8 +5865,14 @@
         "text-field": "{housenumber}",
         "text-size": {
           "stops": [
-            [17, 9],
-            [18, 11]
+            [
+              17,
+              9
+            ],
+            [
+              18,
+              11
+            ]
           ]
         },
         "text-font": [


### PR DESCRIPTION
**Original PR**: https://github.com/CartoDB/basemap-styles/pull/29/files
**Shortcut**: https://app.shortcut.com/cartoteam/story/246204

After following the [basemaps wiki instructions](https://github.com/CartoDB/oncall/wiki/Basemaps#styles-update) apparently we need to run `styler.py`:

```
$ python styler.py -t style_tpl.json -v dark-matter_vars.json -o dark-matter.json
Wrote `dark-matter.json`

$ python styler.py -t style_nolabels_tpl.json -v dark-matter_vars.json -o dark-matter-nolabels.json
Wrote `dark-matter-nolabels.json`
```

Most of the changes are just **JSON pretty format**, however, there are some others like the ones below

```diff
{
   "version": 8,
   "name": "Dark Matter without labels",
-  "metadata": { "maputnik:renderer": "mbgljs" },
+  "metadata": {},
   "sources": {
     "carto": {
       "type": "vector",
-      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json"
+      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json{api_key}"
     }
   },
   "sprite": "https://tiles.basemaps.cartocdn.com/gl/dark-matter-gl-style/sprite",
@@ -14,8 +14,13 @@
     {
       "id": "background",
       "type": "background",
-      "layout": { "visibility": "visible" },
-      "paint": { "background-color": "#0e0e0e", "background-opacity": 1 }
+      "layout": {
+        "visibility": "visible"
+      },
+      "paint": {
+        "background-color": "#0e0e0e",
+        "background-opacity": 1
+      }
     },
     {
       "id": "landcover",
@@ -24,18 +29,45 @@
       "source-layer": "landcover",
       "filter": [
         "any",
-        ["==", "class", "wood"],
-        ["==", "class", "grass"],
-        ["==", "subclass", "recreation_ground"]
+        [
+          "==",
+          "class",
+          "wood"
+        ],
+        [
+          "==",
+          "class",
+          "grass"
+        ],
+        [
+          "==",
+          "subclass",
+          "recreation_ground"
+        ]
       "source": "carto",
       "source-layer": "waterway",
       "paint": {
-        "line-color": "rgba(63, 90, 109, 1)",
+        "line-color": "#151515",
         "line-width": {
           "stops": [
-            [8, 0.5],
-            [9, 1],
-            [15, 2],
-            [16, 3]
+            [
+              8,
+              0.5
+            ],
+            [
+              9,
+              1
+            ],
+            [
+              15,
+              2
+            ],
+            [
+              16,
+              3
+            ]
```

I need to double check it, but for instance, check the change below

```diff
       "source": "carto",
       "source-layer": "waterway",
       "paint": {
-        "line-color": "rgba(63, 90, 109, 1)",
+        "line-color": "#151515",
```

## Updating `bmp-01.stag.cartodb.net`
- [update-all-maps-styles](http://deploy.int.cartodb.net/view/Basemaps/job/basemaps-update-all-styles-staging/38/) ran automatically

```
[basemaps-st] ubuntu@bmp-01:/srv/www/tileserver/shared/cached-copy-basemap-styles/mapboxgl$ ls -ltr
total 736
-rw-rw-r-- 1 ubuntu ubuntu   3655 Oct 25  2019 voyager_vars.json
-rw-rw-r-- 1 ubuntu ubuntu 106842 Oct 25  2019 voyager.json
-rw-rw-r-- 1 ubuntu ubuntu 107607 Oct 25  2019 style_tpl.json
-rwxrwxr-x 1 ubuntu ubuntu   2002 Oct 25  2019 styler.py
-rw-rw-r-- 1 ubuntu ubuntu    728 Oct 25  2019 readme.md
-rw-rw-r-- 1 ubuntu ubuntu   3632 Oct 25  2019 positron_vars.json
-rw-rw-r-- 1 ubuntu ubuntu 106887 Oct 25  2019 positron.json
-rw-rw-r-- 1 ubuntu ubuntu   3480 Oct 25  2019 dark-matter_vars.json
-rw-rw-r-- 1 ubuntu ubuntu  70924 Oct 28  2020 positron-nolabels.json
-rw-rw-r-- 1 ubuntu ubuntu  70984 Oct 28  2020 voyager-nolabels.json
-rw-rw-r-- 1 ubuntu ubuntu  71348 Oct 28  2020 style_nolabels_tpl.json
-rw-rw-r-- 1 ubuntu ubuntu  70637 Jul 20 06:29 dark-matter-nolabels.json
-rw-rw-r-- 1 ubuntu ubuntu 106324 Jul 20 06:29 dark-matter.json
```

## Result

![basemaps3](https://user-images.githubusercontent.com/15977491/179913290-b5884d0e-86c2-4a1b-967c-e62fb8b26bc8.png)

As you can see, the improvements added by @VictorVelarde are gone, so definitely it seems that we shouldn't go for `styler.py`, however, we might need to keep the `{api_key}` field in the URL, since there are some **legacy clients** still using basemaps `api_kyes`, however most of them should be using `raster` instead of vector.

```diff
{
   "version": 8,
   "name": "Dark Matter without labels",
-  "metadata": { "maputnik:renderer": "mbgljs" },
+  "metadata": {},
   "sources": {
     "carto": {
       "type": "vector",
-      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json"
+      "url": "https://tiles.basemaps.cartocdn.com/vector/carto.streets/v1/tiles.json{api_key}"
     }
   },
```
